### PR TITLE
infra(marketplace): clear project-level enabledPlugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,3 @@
 {
-  "enabledPlugins": {
-    "mj-doc@mj-agentlab-marketplace": true,
-    "mj-git@mj-agentlab-marketplace": true
-  }
+  "enabledPlugins": {}
 }


### PR DESCRIPTION
## 变更摘要
清除 `.claude/settings.json` 中的 `enabledPlugins` 配置，移除 `mj-doc` 和 `mj-git` 插件条目，改由用户/全局级别管理插件激活。

## 影响评估
- 仅影响 Claude Code 项目级插件设置
- 不影响 CI/CD 流水线或其他基础设施
- 插件仍可通过用户级别设置启用

## 审核要点
- settings.json 格式正确性
- 确认不再需要项目级插件绑定

## 自检结果
- [x] 配置文件语法正确
- [x] CI/CD 流水线不受影响（或已同步更新）
- [x] 无硬编码敏感信息（密钥、IP、密码）
- [x] Commit message 符合规范（仅含 `infra` / `docs` 类型）

🤖 Generated with [Claude Code](https://claude.com/claude-code)