### PR TITLE
docs(marketplace): sync README version badge to 1.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MJ AgentLab Marketplace
 
-![Version](https://img.shields.io/badge/version-1.1.3-blue)
+![Version](https://img.shields.io/badge/version-1.1.4-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 [![CI](https://github.com/MJ-AgentLab/mj-agentlab-marketplace/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/MJ-AgentLab/mj-agentlab-marketplace/actions/workflows/ci.yml)
 
@@ -15,7 +15,7 @@ MJ System 团队的 [Claude Code](https://docs.anthropic.com/en/docs/claude-code
 | [**mj-doc**](plugins/mj-doc/README.md) | 文档工作流：规划、编写、校验、迁移、同步、审查 | 6 | 1.1.0 | — |
 | [**mj-git**](plugins/mj-git/README.md) | Git 工作流：分支、提交、推送、PR、Review、同步、清理 | 9 | 1.1.0 | `GITHUB_PERSONAL_ACCESS_TOKEN` |
 | [**mj-n8n**](plugins/mj-n8n/README.md) | n8n 工作流：设计、编写、模板、配置、文档、渲染、晋升 | 7 | 1.1.0 | — |
-| [**mj-ops**](plugins/mj-ops/README.md) | 运维操作：环境搭建/清理、ETL 触发 | 4 | 1.1.0 | `SSH_SERVER_*_PASSWORD` |
+| [**mj-ops**](plugins/mj-ops/README.md) | 运维操作：环境搭建/清理、ETL 触发 | 4 | 1.2.0 | `SSH_SERVER_*_PASSWORD` |
 
 ## 安装
 


### PR DESCRIPTION
## 变更摘要

同步 README.md 版本标注：
- version badge: 1.1.3 → 1.1.4
- 插件表 mj-ops Version: 1.1.0 → 1.2.0

此变更在 Release v1.1.4 PR #20 合并后推送到 develop，未被包含。

## 自检结果
- [x] 仅文档变更，无代码改动
