### PR TITLE
infra(mj-ops): remove hardcoded credentials from WAN fallback

### DIFF
--- a/plugins/mj-ops/.mcp.json
+++ b/plugins/mj-ops/.mcp.json
@@ -29,7 +29,7 @@
         "/c", "npx",
         "-y",
         "@modelcontextprotocol/server-postgres",
-        "${MJ_POSTGRES_TEST_WAN_URL:-postgresql://admin:admin123@8.135.38.175:25432/mj_system_db}"
+        "${MJ_POSTGRES_TEST_WAN_URL}"
       ],
       "env": {}
     },
@@ -51,7 +51,7 @@
         "/c", "npx",
         "-y",
         "@modelcontextprotocol/server-postgres",
-        "${MJ_POSTGRES_PROD_WAN_URL:-postgresql://admin:admin123@8.135.38.175:35432/mj_system_db}"
+        "${MJ_POSTGRES_PROD_WAN_URL}"
       ],
       "env": {}
     },

--- a/plugins/mj-ops/CHANGELOG.md
+++ b/plugins/mj-ops/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 ## [Unreleased]
 
+### Changed
+- PostgreSQL WAN MCP 条目（postgres-test-wan、postgres-prod-wan）移除 fallback 硬编码凭据，未配置环境变量时连接失败而非静默使用默认凭据
+- env-reference.md 中 WAN URL 变量从「可选」调整为「WAN 必填」
+
 ## [1.2.0] - 2026-03-20
 
 ### Fixed

--- a/plugins/mj-ops/CLAUDE.md
+++ b/plugins/mj-ops/CLAUDE.md
@@ -18,9 +18,9 @@ mj-ops 是 MJ System 的运维技能家族 Plugin，提供 4 个 skill：
 **PostgreSQL（5 个）：**
 - **postgres-dev**: 本地开发环境（`${MJ_POSTGRES_DEV_URL}` 或默认 localhost:5432）
 - **postgres-test-lan**: 测试环境 LAN（`${MJ_POSTGRES_TEST_LAN_URL}` 或默认 192.168.0.179:5432）
-- **postgres-test-wan**: 测试环境 WAN（`${MJ_POSTGRES_TEST_WAN_URL}` 或默认 8.135.38.175:25432）
+- **postgres-test-wan**: 测试环境 WAN（需配置 `MJ_POSTGRES_TEST_WAN_URL`，无 fallback 默认值）
 - **postgres-prod-lan**: 生产环境 LAN（`${MJ_POSTGRES_PROD_LAN_URL}` 或默认 192.168.0.106:5432）
-- **postgres-prod-wan**: 生产环境 WAN（`${MJ_POSTGRES_PROD_WAN_URL}` 或默认 8.135.38.175:35432）
+- **postgres-prod-wan**: 生产环境 WAN（需配置 `MJ_POSTGRES_PROD_WAN_URL`，无 fallback 默认值）
 
 **SSH（ssh-manager，7 台服务器）：**
 - **CLOUD**: 云服务器 8.135.38.175（需 `SSH_SERVER_CLOUD_PASSWORD`）

--- a/plugins/mj-ops/skills/mj-env-setup/env-reference.md
+++ b/plugins/mj-ops/skills/mj-env-setup/env-reference.md
@@ -95,9 +95,9 @@
 | `SSH_SERVER_PROD_PASSWORD` | 可选 | 向团队获取 | SSH MCP 生产服务器密码（LAN + WAN 共用） |
 | `MJ_POSTGRES_DEV_URL` | 可选 | 默认 localhost:5432 | 覆盖本地开发 PostgreSQL MCP 连接串 |
 | `MJ_POSTGRES_TEST_LAN_URL` | 可选 | 默认 192.168.0.179:5432 | 覆盖测试环境 LAN PostgreSQL MCP 连接串 |
-| `MJ_POSTGRES_TEST_WAN_URL` | 可选 | 默认 8.135.38.175:25432 | 覆盖测试环境 WAN PostgreSQL MCP 连接串 |
+| `MJ_POSTGRES_TEST_WAN_URL` | **WAN 必填** | 向团队获取 | 测试环境 WAN PostgreSQL MCP 连接串（无 fallback，未设置则连接失败） |
 | `MJ_POSTGRES_PROD_LAN_URL` | 可选 | 默认 192.168.0.106:5432 | 覆盖生产环境 LAN PostgreSQL MCP 连接串 |
-| `MJ_POSTGRES_PROD_WAN_URL` | 可选 | 默认 8.135.38.175:35432 | 覆盖生产环境 WAN PostgreSQL MCP 连接串 |
+| `MJ_POSTGRES_PROD_WAN_URL` | **WAN 必填** | 向团队获取 | 生产环境 WAN PostgreSQL MCP 连接串（无 fallback，未设置则连接失败） |
 
 ---
 


### PR DESCRIPTION
## 变更摘要

移除 `.mcp.json` 中 `postgres-test-wan` 和 `postgres-prod-wan` 的 fallback 硬编码凭据（`admin:admin123`），改为无默认值模式。未配置环境变量时 MCP 连接失败，而非静默使用硬编码凭据经公网传输。

LAN 条目（postgres-dev / postgres-test-lan / postgres-prod-lan）保持不变，保留开箱即用体验。

Closes #18

## 影响评估

| 影响范围 | 说明 |
|---------|------|
| `postgres-test-wan` | 需提前配置 `MJ_POSTGRES_TEST_WAN_URL` 系统环境变量 |
| `postgres-prod-wan` | 需提前配置 `MJ_POSTGRES_PROD_WAN_URL` 系统环境变量 |
| LAN 条目 | 不受影响 |
| SSH MCP | 不受影响 |

## 审核要点

1. `.mcp.json` 中 WAN 条目是否正确移除了 `:-fallback` 部分
2. LAN 条目是否保持原样（仍有 fallback 默认值）
3. `CLAUDE.md` 和 `env-reference.md` 是否同步标注 WAN 需手动配置
4. JSON 格式合法性

## 自检结果
- [x] 配置文件语法正确（`node -e JSON.parse` 验证通过）
- [x] CI/CD 流水线不受影响
- [x] 无硬编码敏感信息（WAN fallback 已移除，LAN 保留内网默认值）
- [x] Commit message 符合规范（仅含 `infra` 类型）
