### PR TITLE
infra(secrets): add -md sha256 to openssl enc for cross-version compatibility

### DIFF
--- a/plugins/mj-git/scripts/encrypt-git-secrets.ps1
+++ b/plugins/mj-git/scripts/encrypt-git-secrets.ps1
@@ -67,7 +67,7 @@ if ($Password1 -ne $Password2) {
 $Password = $Password1
 
 # ── Encrypt ───────────────────────────────────────────────────────────
-$Password | & $OpenSSL enc -aes-256-cbc -pbkdf2 -salt -in $ConfFile -out $EncFile -pass stdin 2>&1
+$Password | & $OpenSSL enc -aes-256-cbc -pbkdf2 -md sha256 -salt -in $ConfFile -out $EncFile -pass stdin 2>&1
 if ($LASTEXITCODE -ne 0) {
     Write-Host "[ERROR] Encryption failed." -ForegroundColor Red
     exit 1

--- a/plugins/mj-git/scripts/setup-git-env.ps1
+++ b/plugins/mj-git/scripts/setup-git-env.ps1
@@ -143,7 +143,7 @@ $Password = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto(
 
 # ── Decrypt ───────────────────────────────────────────────────────────
 try {
-    $Password | & $OpenSSL enc -aes-256-cbc -pbkdf2 -d -in $EncFile -out $ConfFile -pass stdin 2>&1
+    $Password | & $OpenSSL enc -aes-256-cbc -pbkdf2 -md sha256 -d -in $EncFile -out $ConfFile -pass stdin 2>&1
     if ($LASTEXITCODE -ne 0) { throw "Decryption failed" }
 
     # ── Parse secrets ─────────────────────────────────────────────────

--- a/plugins/mj-ops/scripts/encrypt-ops-secrets.ps1
+++ b/plugins/mj-ops/scripts/encrypt-ops-secrets.ps1
@@ -67,7 +67,7 @@ if ($Password1 -ne $Password2) {
 $Password = $Password1
 
 # ── Encrypt ───────────────────────────────────────────────────────────
-$Password | & $OpenSSL enc -aes-256-cbc -pbkdf2 -salt -in $ConfFile -out $EncFile -pass stdin 2>&1
+$Password | & $OpenSSL enc -aes-256-cbc -pbkdf2 -md sha256 -salt -in $ConfFile -out $EncFile -pass stdin 2>&1
 if ($LASTEXITCODE -ne 0) {
     Write-Host "[ERROR] Encryption failed." -ForegroundColor Red
     exit 1

--- a/plugins/mj-ops/scripts/setup-ops-env.ps1
+++ b/plugins/mj-ops/scripts/setup-ops-env.ps1
@@ -143,7 +143,7 @@ $Password = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto(
 
 # ── Decrypt ───────────────────────────────────────────────────────────
 try {
-    $Password | & $OpenSSL enc -aes-256-cbc -pbkdf2 -d -in $EncFile -out $ConfFile -pass stdin 2>&1
+    $Password | & $OpenSSL enc -aes-256-cbc -pbkdf2 -md sha256 -d -in $EncFile -out $ConfFile -pass stdin 2>&1
     if ($LASTEXITCODE -ne 0) { throw "Decryption failed" }
 
     # ── Parse secrets ─────────────────────────────────────────────────


### PR DESCRIPTION
## 变更摘要

mj-ops 和 mj-git 插件的 4 个加解密脚本添加 `-md sha256` 参数，与 mj-system 主仓库保持一致，消除 OpenSSL 版本间 PBKDF2 摘要算法差异。

**修改范围**：
- `plugins/mj-ops/scripts/setup-ops-env.ps1` — 解密命令
- `plugins/mj-ops/scripts/encrypt-ops-secrets.ps1` — 加密命令
- `plugins/mj-git/scripts/setup-git-env.ps1` — 解密命令
- `plugins/mj-git/scripts/encrypt-git-secrets.ps1` — 加密命令

> 关联 PR：MJ-AgentLab/mj-system 同仓库同步修复

## 影响评估

- **开发环境**：直接受益 — 任何 OpenSSL 1.1.0+ 版本均可正常解密插件密钥
- **测试/生产环境**：无影响
- **注意**：如果 `ops-secrets.enc` 或 `git-secrets.enc` 由 OpenSSL 1.x 创建，需管理员用更新后的脚本重新加密

## 审核要点

1. 确认 4 处 `openssl enc` 命令均已添加 `-md sha256`
2. 确认与 mj-system 主仓库的修复方式一致

## 自检结果
- [x] 配置文件语法正确
- [x] CI/CD 流水线不受影响
- [x] Docker 构建通过（不涉及）
- [x] 无硬编码敏感信息
- [x] Commit message 符合规范（仅含 `infra` 类型）
