### PR TITLE
infra(secrets): fix OpenSSL Find priority in plugin scripts — prefer Git over Anaconda PATH (#30)

### DIFF
--- a/plugins/mj-git/scripts/encrypt-git-secrets.ps1
+++ b/plugins/mj-git/scripts/encrypt-git-secrets.ps1
@@ -38,14 +38,17 @@ if (-not (Test-Path $ConfFile)) {
 
 # ── OpenSSL lookup ────────────────────────────────────────────────────
 function Find-OpenSSL {
-    $cmd = Get-Command openssl -ErrorAction SilentlyContinue
-    if ($cmd) { return $cmd.Source }
+    # Prefer Git for Windows' OpenSSL — standard build, consistent behavior.
+    # Anaconda/conda OpenSSL in PATH can cause "bad decrypt" due to build differences.
     $gitOpenSSL = "C:\Program Files\Git\usr\bin\openssl.exe"
     if (Test-Path $gitOpenSSL) { return $gitOpenSSL }
+    $cmd = Get-Command openssl -ErrorAction SilentlyContinue
+    if ($cmd) { return $cmd.Source }
     Write-Host "[ERROR] openssl not found. Install Git for Windows or add openssl to PATH." -ForegroundColor Red
     exit 1
 }
 $OpenSSL = Find-OpenSSL
+Write-Host "  Using OpenSSL: $OpenSSL" -ForegroundColor DarkGray
 
 # ── Password prompt (double input) ───────────────────────────────────
 Write-Host ""

--- a/plugins/mj-git/scripts/setup-git-env.ps1
+++ b/plugins/mj-git/scripts/setup-git-env.ps1
@@ -50,14 +50,17 @@ $EnvFile  = Join-Path $PluginRoot ".env"
 
 # ── OpenSSL lookup ────────────────────────────────────────────────────
 function Find-OpenSSL {
-    $cmd = Get-Command openssl -ErrorAction SilentlyContinue
-    if ($cmd) { return $cmd.Source }
+    # Prefer Git for Windows' OpenSSL — standard build, consistent behavior.
+    # Anaconda/conda OpenSSL in PATH can cause "bad decrypt" due to build differences.
     $gitOpenSSL = "C:\Program Files\Git\usr\bin\openssl.exe"
     if (Test-Path $gitOpenSSL) { return $gitOpenSSL }
+    $cmd = Get-Command openssl -ErrorAction SilentlyContinue
+    if ($cmd) { return $cmd.Source }
     Write-Host "[ERROR] openssl not found. Install Git for Windows or add openssl to PATH." -ForegroundColor Red
     exit 1
 }
 $OpenSSL = Find-OpenSSL
+Write-Host "  Using OpenSSL: $OpenSSL" -ForegroundColor DarkGray
 
 # ── Helper: mask value for display ────────────────────────────────────
 function Format-MaskedValue([string]$Value) {

--- a/plugins/mj-ops/scripts/encrypt-ops-secrets.ps1
+++ b/plugins/mj-ops/scripts/encrypt-ops-secrets.ps1
@@ -38,14 +38,17 @@ if (-not (Test-Path $ConfFile)) {
 
 # ── OpenSSL lookup ────────────────────────────────────────────────────
 function Find-OpenSSL {
-    $cmd = Get-Command openssl -ErrorAction SilentlyContinue
-    if ($cmd) { return $cmd.Source }
+    # Prefer Git for Windows' OpenSSL — standard build, consistent behavior.
+    # Anaconda/conda OpenSSL in PATH can cause "bad decrypt" due to build differences.
     $gitOpenSSL = "C:\Program Files\Git\usr\bin\openssl.exe"
     if (Test-Path $gitOpenSSL) { return $gitOpenSSL }
+    $cmd = Get-Command openssl -ErrorAction SilentlyContinue
+    if ($cmd) { return $cmd.Source }
     Write-Host "[ERROR] openssl not found. Install Git for Windows or add openssl to PATH." -ForegroundColor Red
     exit 1
 }
 $OpenSSL = Find-OpenSSL
+Write-Host "  Using OpenSSL: $OpenSSL" -ForegroundColor DarkGray
 
 # ── Password prompt (double input) ───────────────────────────────────
 Write-Host ""

--- a/plugins/mj-ops/scripts/setup-ops-env.ps1
+++ b/plugins/mj-ops/scripts/setup-ops-env.ps1
@@ -50,14 +50,17 @@ $EnvFile  = Join-Path $PluginRoot ".env"
 
 # ── OpenSSL lookup ────────────────────────────────────────────────────
 function Find-OpenSSL {
-    $cmd = Get-Command openssl -ErrorAction SilentlyContinue
-    if ($cmd) { return $cmd.Source }
+    # Prefer Git for Windows' OpenSSL — standard build, consistent behavior.
+    # Anaconda/conda OpenSSL in PATH can cause "bad decrypt" due to build differences.
     $gitOpenSSL = "C:\Program Files\Git\usr\bin\openssl.exe"
     if (Test-Path $gitOpenSSL) { return $gitOpenSSL }
+    $cmd = Get-Command openssl -ErrorAction SilentlyContinue
+    if ($cmd) { return $cmd.Source }
     Write-Host "[ERROR] openssl not found. Install Git for Windows or add openssl to PATH." -ForegroundColor Red
     exit 1
 }
 $OpenSSL = Find-OpenSSL
+Write-Host "  Using OpenSSL: $OpenSSL" -ForegroundColor DarkGray
 
 # ── Helper: mask value for display ────────────────────────────────────
 function Format-MaskedValue([string]$Value) {


### PR DESCRIPTION
## 变更摘要

修复 mj-ops 和 mj-git 插件中 4 个 PowerShell secrets 脚本的 `Find-OpenSSL` 函数查找优先级。

**问题**：与 [mj-system#106](https://github.com/MJ-AgentLab/mj-system/issues/106) 同源。团队成员 PATH 中有 Anaconda 的 OpenSSL，被脚本优先找到，导致解密 secrets 文件时报 "bad decrypt"。

**修复**：反转查找顺序——优先使用 Git for Windows 自带的标准 OpenSSL，回退到 PATH。同时添加诊断输出。

Closes #30

## 影响评估

- **影响环境**：所有开发者本地环境
- **受影响脚本**（4 个）：
  - `plugins/mj-ops/scripts/setup-ops-env.ps1`
  - `plugins/mj-ops/scripts/encrypt-ops-secrets.ps1`
  - `plugins/mj-git/scripts/setup-git-env.ps1`
  - `plugins/mj-git/scripts/encrypt-git-secrets.ps1`
- **向后兼容**：完全兼容，只改查找顺序

## 审核要点

1. `Find-OpenSSL` 函数在 4 个脚本中保持一致
2. 与 mj-system [PR #107](https://github.com/MJ-AgentLab/mj-system/pull/107) 修复方式完全相同

## 自检结果
- [x] 配置文件语法正确
- [x] CI/CD 流水线不受影响
- [x] 无硬编码敏感信息
- [x] Commit message 符合规范（仅含 `infra` 类型）
