### PR TITLE
infra(secrets): derive Git OpenSSL path dynamically — fix non-standard Git install (#32)

### DIFF
--- a/plugins/mj-git/scripts/encrypt-git-secrets.ps1
+++ b/plugins/mj-git/scripts/encrypt-git-secrets.ps1
@@ -40,8 +40,18 @@ if (-not (Test-Path $ConfFile)) {
 function Find-OpenSSL {
     # Prefer Git for Windows' OpenSSL — standard build, consistent behavior.
     # Anaconda/conda OpenSSL in PATH can cause "bad decrypt" due to build differences.
-    $gitOpenSSL = "C:\Program Files\Git\usr\bin\openssl.exe"
-    if (Test-Path $gitOpenSSL) { return $gitOpenSSL }
+    # 1. Derive from git.exe location (works for any Git install path)
+    #    git.exe may be at <root>/cmd/, <root>/bin/, or <root>/mingw64/bin/
+    $gitCmd = Get-Command git -ErrorAction SilentlyContinue
+    if ($gitCmd) {
+        $dir = Split-Path $gitCmd.Source
+        for ($i = 0; $i -lt 4; $i++) {
+            $candidate = Join-Path $dir "usr\bin\openssl.exe"
+            if (Test-Path $candidate) { return $candidate }
+            $dir = Split-Path $dir
+        }
+    }
+    # 2. Last resort: PATH (may find Anaconda — known to cause issues)
     $cmd = Get-Command openssl -ErrorAction SilentlyContinue
     if ($cmd) { return $cmd.Source }
     Write-Host "[ERROR] openssl not found. Install Git for Windows or add openssl to PATH." -ForegroundColor Red

--- a/plugins/mj-git/scripts/setup-git-env.ps1
+++ b/plugins/mj-git/scripts/setup-git-env.ps1
@@ -52,8 +52,18 @@ $EnvFile  = Join-Path $PluginRoot ".env"
 function Find-OpenSSL {
     # Prefer Git for Windows' OpenSSL — standard build, consistent behavior.
     # Anaconda/conda OpenSSL in PATH can cause "bad decrypt" due to build differences.
-    $gitOpenSSL = "C:\Program Files\Git\usr\bin\openssl.exe"
-    if (Test-Path $gitOpenSSL) { return $gitOpenSSL }
+    # 1. Derive from git.exe location (works for any Git install path)
+    #    git.exe may be at <root>/cmd/, <root>/bin/, or <root>/mingw64/bin/
+    $gitCmd = Get-Command git -ErrorAction SilentlyContinue
+    if ($gitCmd) {
+        $dir = Split-Path $gitCmd.Source
+        for ($i = 0; $i -lt 4; $i++) {
+            $candidate = Join-Path $dir "usr\bin\openssl.exe"
+            if (Test-Path $candidate) { return $candidate }
+            $dir = Split-Path $dir
+        }
+    }
+    # 2. Last resort: PATH (may find Anaconda — known to cause issues)
     $cmd = Get-Command openssl -ErrorAction SilentlyContinue
     if ($cmd) { return $cmd.Source }
     Write-Host "[ERROR] openssl not found. Install Git for Windows or add openssl to PATH." -ForegroundColor Red

--- a/plugins/mj-ops/scripts/encrypt-ops-secrets.ps1
+++ b/plugins/mj-ops/scripts/encrypt-ops-secrets.ps1
@@ -40,8 +40,18 @@ if (-not (Test-Path $ConfFile)) {
 function Find-OpenSSL {
     # Prefer Git for Windows' OpenSSL — standard build, consistent behavior.
     # Anaconda/conda OpenSSL in PATH can cause "bad decrypt" due to build differences.
-    $gitOpenSSL = "C:\Program Files\Git\usr\bin\openssl.exe"
-    if (Test-Path $gitOpenSSL) { return $gitOpenSSL }
+    # 1. Derive from git.exe location (works for any Git install path)
+    #    git.exe may be at <root>/cmd/, <root>/bin/, or <root>/mingw64/bin/
+    $gitCmd = Get-Command git -ErrorAction SilentlyContinue
+    if ($gitCmd) {
+        $dir = Split-Path $gitCmd.Source
+        for ($i = 0; $i -lt 4; $i++) {
+            $candidate = Join-Path $dir "usr\bin\openssl.exe"
+            if (Test-Path $candidate) { return $candidate }
+            $dir = Split-Path $dir
+        }
+    }
+    # 2. Last resort: PATH (may find Anaconda — known to cause issues)
     $cmd = Get-Command openssl -ErrorAction SilentlyContinue
     if ($cmd) { return $cmd.Source }
     Write-Host "[ERROR] openssl not found. Install Git for Windows or add openssl to PATH." -ForegroundColor Red

--- a/plugins/mj-ops/scripts/setup-ops-env.ps1
+++ b/plugins/mj-ops/scripts/setup-ops-env.ps1
@@ -52,8 +52,18 @@ $EnvFile  = Join-Path $PluginRoot ".env"
 function Find-OpenSSL {
     # Prefer Git for Windows' OpenSSL — standard build, consistent behavior.
     # Anaconda/conda OpenSSL in PATH can cause "bad decrypt" due to build differences.
-    $gitOpenSSL = "C:\Program Files\Git\usr\bin\openssl.exe"
-    if (Test-Path $gitOpenSSL) { return $gitOpenSSL }
+    # 1. Derive from git.exe location (works for any Git install path)
+    #    git.exe may be at <root>/cmd/, <root>/bin/, or <root>/mingw64/bin/
+    $gitCmd = Get-Command git -ErrorAction SilentlyContinue
+    if ($gitCmd) {
+        $dir = Split-Path $gitCmd.Source
+        for ($i = 0; $i -lt 4; $i++) {
+            $candidate = Join-Path $dir "usr\bin\openssl.exe"
+            if (Test-Path $candidate) { return $candidate }
+            $dir = Split-Path $dir
+        }
+    }
+    # 2. Last resort: PATH (may find Anaconda — known to cause issues)
     $cmd = Get-Command openssl -ErrorAction SilentlyContinue
     if ($cmd) { return $cmd.Source }
     Write-Host "[ERROR] openssl not found. Install Git for Windows or add openssl to PATH." -ForegroundColor Red


### PR DESCRIPTION
## 变更摘要

修复 #30 遗留问题：`Find-OpenSSL` 硬编码 `C:\Program Files\Git\usr\bin\openssl.exe` 在非标准 Git 安装路径下失效。改为从 `Get-Command git` 动态推导，向上遍历目录查找 `usr\bin\openssl.exe`。

与 mj-system [PR #108](https://github.com/MJ-AgentLab/mj-system/pull/108) 同源修复。

Closes #32

## 影响评估
- **影响环境**：Git 安装在非默认路径的开发者
- **向后兼容**：完全兼容

## 审核要点
1. 4 个脚本的 `Find-OpenSSL` 函数保持一致
2. 向上遍历逻辑支持 `cmd/`、`bin/`、`mingw64/bin/` 等各种 git.exe 位置

## 自检结果
- [x] 配置文件语法正确
- [x] CI/CD 流水线不受影响
- [x] 无硬编码敏感信息
- [x] Commit message 符合规范（仅含 `infra` 类型）
