### PR TITLE
fix(mj-n8n): add DateTime timezone conventions to prevent UTC display in notifications

### DIFF
--- a/plugins/mj-n8n/CHANGELOG.md
+++ b/plugins/mj-n8n/CHANGELOG.md
@@ -5,6 +5,14 @@
 
 ## [Unreleased]
 
+### Fixed
+- 修正 WeChat 通知模板时间字段：从 `toISOString()`（UTC）改为 Luxon `DateTime` 显示北京时间
+- 新增 node-patterns.md Section 10「DateTime Formatting Conventions」，明确用户可见时间 vs 内部日志的处理约定
+- author SKILL.md Step 3 新增 DateTime 处理规则，Step 4 Log 模板增加时区注释
+- naming-reference.md 新增 DateTime 约定指针引用
+- promotion-checklist.md DEV 验证清单新增「通知时间戳显示北京时间」检查项
+- template SKILL.md Common Pitfalls 新增 Pitfall 8：不要模板化 Luxon 时区字符串
+
 ## [1.1.0] - 2026-03-17
 
 ### Changed

--- a/plugins/mj-n8n/skills/mj-n8n-author/SKILL.md
+++ b/plugins/mj-n8n/skills/mj-n8n-author/SKILL.md
@@ -139,6 +139,12 @@ digraph author {
 
 详细模板见 `→ node-patterns.md` Section 3f-3j。
 
+**DateTime 处理规则**：
+- 用户可见时间（通知消息、报告内容）：使用 Luxon `DateTime.fromJSDate(new Date(date)).setZone('Asia/Shanghai').toFormat('yyyy-MM-dd HH:mm')`
+- 内部日志 `timestamp` 字段：使用 `new Date().toISOString()`（UTC ISO 格式）
+- `DateTime`（Luxon）在 n8n Code 节点中为全局对象，无需 import
+- 详见 `→ node-patterns.md` Section 10
+
 ---
 
 ### Step 4 — Error Handling（错误处理节点）
@@ -165,7 +171,7 @@ return [{
     logType: 'WORKFLOW_EXECUTION',           // 或 VALIDATION_SKIPPED, STEP_ERROR, DATA_TYPE_SKIPPED, NO_DATA_FOUND
     workflowName: '{{ENV_PREFIX}}-{Category}-{Name}-{TriggerType}',
     executionId: $execution.id,
-    timestamp: new Date().toISOString(),
+    timestamp: new Date().toISOString(),      // 内部日志用 UTC；用户可见时间用 Luxon（见 node-patterns.md Section 10）
     status: 'SUCCESS',                       // SUCCESS, SKIPPED, ERROR, NO_ACTION, COMPLETED_WITH_WARNINGS, FAILED
     environment: '{{ENV_NAME}}',
     // ... context-specific fields

--- a/plugins/mj-n8n/skills/mj-n8n-author/node-patterns.md
+++ b/plugins/mj-n8n/skills/mj-n8n-author/node-patterns.md
@@ -477,12 +477,18 @@ IF 节点命名规范：
 // Note: markdown_v2 does not support font color tags
 // ============================================================
 
+const formatDateTime = (date) => {
+  return DateTime.fromJSDate(new Date(date))
+    .setZone('Asia/Shanghai')
+    .toFormat('yyyy-MM-dd HH:mm');
+};
+
 const data = $input.first().json;
 
 const content = `${statusIcon} **${title}**
 
 > 环境: {{ENV_NAME}}
-> 时间: ${new Date().toISOString()}
+> 时间: ${formatDateTime(new Date())}
 > 执行ID: ${$execution.id}
 
 **状态**: ${status}
@@ -621,3 +627,58 @@ return [{
   }
 }];
 ```
+
+---
+
+## 10. DateTime Formatting Conventions
+
+n8n Code 节点中 `DateTime`（Luxon）为全局对象，无需 import。这是 n8n 官方推荐的日期处理方式。
+
+### 用户可见时间（通知、报告、消息）
+
+所有面向用户的时间显示必须使用北京时间。推荐使用显式 `.setZone()` 确保代码自包含、不依赖容器配置：
+
+**单次使用（inline）**：
+```javascript
+DateTime.fromJSDate(new Date()).setZone('Asia/Shanghai').toFormat('yyyy-MM-dd HH:mm')
+// 输出示例：2026-04-01 10:00
+```
+
+**多次使用（辅助函数）**：
+```javascript
+const formatDateTime = (date) => {
+  return DateTime.fromJSDate(new Date(date))
+    .setZone('Asia/Shanghai')
+    .toFormat('yyyy-MM-dd HH:mm');
+};
+```
+
+**替代方案**：`$now.toFormat('yyyy-MM-dd HH:mm')` 也可用于当前时间（`$now` 是 Luxon 对象，遵循 `GENERIC_TIMEZONE` 配置），但显式 `.setZone()` 更安全——不依赖环境配置。
+
+### 避免在用户可见内容中使用的方法
+
+| 方法 | 问题 |
+|------|------|
+| `new Date().getHours()` / `.getMinutes()` | 返回容器操作系统时区时间；若 Docker 未设 `TZ`，返回 UTC，比北京时间早 8 小时 |
+| `new Date().toLocaleString()` | 输出依赖 Node.js 打包的 ICU 数据，不同版本格式可能不一致（如有无逗号分隔符），Docker 容器中不可预测 |
+| `new Date().toISOString()` | 输出 `2026-04-01T02:00:00.000Z` 格式，语义正确但用户无法直观识读为北京时间 |
+
+### 内部日志时间戳
+
+Log 节点的 `timestamp` 字段保持 ISO 8601 UTC 格式（与 Section 9 一致）：
+
+```javascript
+// 正确：内部日志使用 UTC ISO 格式，带 Z 后缀语义明确
+timestamp: new Date().toISOString()
+// 输出示例：2026-04-01T02:00:00.000Z
+```
+
+### n8n 时区控制面
+
+| 层级 | 配置 | 影响范围 |
+|------|------|---------|
+| 操作系统层 | `TZ: Asia/Shanghai`（Docker 环境变量） | vanilla JS `Date` 对象的本地时间方法 |
+| n8n 应用层 | `GENERIC_TIMEZONE: Asia/Shanghai` | Luxon `$now` / `$today` / `DateTime.now()` + cron 调度 |
+| 代码层 | `.setZone('Asia/Shanghai')` | 显式指定，不依赖上述任何配置 |
+
+三层独立。代码层 `.setZone()` 是最安全的选择——即使容器或 n8n 配置变更，通知时间仍正确。

--- a/plugins/mj-n8n/skills/mj-n8n-plan/naming-reference.md
+++ b/plugins/mj-n8n/skills/mj-n8n-plan/naming-reference.md
@@ -216,3 +216,9 @@ triggers:
 - 三个环境文件（`dev.yaml`, `test.yaml`, `production.yaml`）均需更新
 - production 可使用不同的 cron 表达式或间隔
 - `timezone` 固定使用 `"Asia/Shanghai"`
+
+---
+
+## DateTime 处理约定
+
+用户可见时间使用 Luxon `DateTime`，内部日志使用 `toISOString()`。详见 `node-patterns.md` Section 10。

--- a/plugins/mj-n8n/skills/mj-n8n-promote/promotion-checklist.md
+++ b/plugins/mj-n8n/skills/mj-n8n-promote/promotion-checklist.md
@@ -12,6 +12,7 @@
 □ API 端点连通（HTTP 200）
 □ 手动完整执行成功
 □ 输出格式正确（通知/日志）
+□ 通知时间戳显示北京时间（非 UTC）
 □ 错误分支处理正常
 □ 环境变量值正确（environment: "dev"）
 □ 标签正确（env:dev, trigger:*, domain:*）

--- a/plugins/mj-n8n/skills/mj-n8n-template/SKILL.md
+++ b/plugins/mj-n8n/skills/mj-n8n-template/SKILL.md
@@ -200,6 +200,8 @@ n8n/workflows/_base/CollectionNodes/RawDataCollection-Scheduled/
 
 7. **n8n 表达式 `{{ }}` 与模板占位符 `{{ }}` 的区分** —— n8n 表达式如 `={{ $json.xxx }}` 中的 `{{ }}` 不是模板占位符。模板占位符命名格式为 `{{UPPER_CASE_NAME}}`（全大写+下划线），渲染脚本通过正则 `\{\{[A-Z][A-Z0-9_]+\}\}` 匹配。
 
+8. **不要模板化 Luxon 时区字符串** —— Code 节点中 `DateTime.fromJSDate(...).setZone('Asia/Shanghai')` 的 `'Asia/Shanghai'` 是固定时区标识符，所有环境相同，不属于环境相关值。不要将其替换为占位符。
+
 ## Human Intervention Points
 
 | # | 触发条件 | 行为 |


### PR DESCRIPTION
## Bug 描述

n8n 工作流通知模板和技能文档缺少时区处理约定，WeChat 通知模板中使用 `new Date().toISOString()` 显示 UTC 时间，未来新建工作流可能重复 UTC 时间显示偏差 8 小时的问题。

## 根因分析

`plugins/mj-n8n` 的技能参考文件（node-patterns.md Section 7）中 WeChat 通知模板使用 `toISOString()` 输出用户可见时间，且全部技能文档中缺少 DateTime 时区处理约定，无法指导开发者正确区分用户可见时间（需北京时间）和内部日志时间戳（UTC ISO 格式）。

## 修复方案

1. **node-patterns.md**：修正 Section 7 WeChat 模板使用 Luxon `formatDateTime` 辅助函数；新增 Section 10「DateTime Formatting Conventions」作为权威参考（含 inline/函数两种模式、避免方法表、日志约定、三层时区控制面）
2. **naming-reference.md**：新增指针引用 → node-patterns.md Section 10（single source of truth）
3. **author SKILL.md**：Step 3 新增 DateTime 处理规则，Step 4 Log 模板 timestamp 行增加注释
4. **promotion-checklist.md**：DEV 验证清单新增「通知时间戳显示北京时间」检查项
5. **template SKILL.md**：Common Pitfalls 新增 Pitfall 8 — 不要模板化 Luxon 时区字符串

## 影响范围

- **Plugin**: mj-n8n（6 个文件）
- **Skills**: mj-n8n-author, mj-n8n-plan, mj-n8n-promote, mj-n8n-template
- **类型**: 纯文档/技能定义变更，不影响运行时行为

## 自检结果
- [x] Bug 已复现并验证修复
- [x] 无引入新的回归问题
- [x] 无残留调试代码
- [x] Commit message 符合规范（仅含 `fix` / `test` / `docs` 类型）
- [x] CHANGELOG.md `[Unreleased]` 区块已更新
