### PR TITLE
fix(mj-ops): override pg type parsers to preserve timestamp timezone (#38)

### DIFF
--- a/plugins/mj-ops/.mcp.json
+++ b/plugins/mj-ops/.mcp.json
@@ -4,9 +4,7 @@
       "type": "stdio",
       "command": "cmd",
       "args": [
-        "/c", "npx",
-        "-y",
-        "@modelcontextprotocol/server-postgres",
+        "/c", "${CLAUDE_PLUGIN_ROOT}/scripts/pg-server-start.cmd",
         "${MJ_POSTGRES_DEV_URL:-postgresql://admin:admin123@localhost:5432/mj_system_db}"
       ],
       "env": {}
@@ -15,9 +13,7 @@
       "type": "stdio",
       "command": "cmd",
       "args": [
-        "/c", "npx",
-        "-y",
-        "@modelcontextprotocol/server-postgres",
+        "/c", "${CLAUDE_PLUGIN_ROOT}/scripts/pg-server-start.cmd",
         "${MJ_POSTGRES_TEST_LAN_URL:-postgresql://admin:admin123@192.168.0.179:5432/mj_system_db}"
       ],
       "env": {}
@@ -26,9 +22,7 @@
       "type": "stdio",
       "command": "cmd",
       "args": [
-        "/c", "npx",
-        "-y",
-        "@modelcontextprotocol/server-postgres",
+        "/c", "${CLAUDE_PLUGIN_ROOT}/scripts/pg-server-start.cmd",
         "${MJ_POSTGRES_TEST_WAN_URL}"
       ],
       "env": {}
@@ -37,9 +31,7 @@
       "type": "stdio",
       "command": "cmd",
       "args": [
-        "/c", "npx",
-        "-y",
-        "@modelcontextprotocol/server-postgres",
+        "/c", "${CLAUDE_PLUGIN_ROOT}/scripts/pg-server-start.cmd",
         "${MJ_POSTGRES_PROD_LAN_URL:-postgresql://admin:admin123@192.168.0.106:5432/mj_system_db}"
       ],
       "env": {}
@@ -48,9 +40,7 @@
       "type": "stdio",
       "command": "cmd",
       "args": [
-        "/c", "npx",
-        "-y",
-        "@modelcontextprotocol/server-postgres",
+        "/c", "${CLAUDE_PLUGIN_ROOT}/scripts/pg-server-start.cmd",
         "${MJ_POSTGRES_PROD_WAN_URL}"
       ],
       "env": {}

--- a/plugins/mj-ops/CHANGELOG.md
+++ b/plugins/mj-ops/CHANGELOG.md
@@ -5,6 +5,18 @@
 
 ## [Unreleased]
 
+## [1.2.4] - 2026-04-02
+
+### Fixed
+- MCP postgres 查询结果中 `timestamp`/`timestamptz` 字段被 node-postgres 转换为 UTC `Z` 格式（如 `2026-04-01T08:51:14.755Z`），现返回 PostgreSQL 原始格式（如 `2026-04-01 16:51:19+08`）(#38)
+
+### Added
+- `scripts/pg-server-start.cmd` — PostgreSQL MCP server 启动脚本，自动发现 npx 缓存并设置 `NODE_PATH`
+- `scripts/pg-server-wrapper.mjs` — ESM wrapper，通过 `pg.types.setTypeParser` 覆盖 OID 1114/1184 的默认解析器
+
+### Changed
+- `.mcp.json` 中 5 个 postgres server 的启动命令从 `npx -y @modelcontextprotocol/server-postgres` 改为 `${CLAUDE_PLUGIN_ROOT}/scripts/pg-server-start.cmd`
+
 ## [1.2.3] - 2026-03-24
 
 ### Fixed

--- a/plugins/mj-ops/CLAUDE.md
+++ b/plugins/mj-ops/CLAUDE.md
@@ -22,6 +22,8 @@ mj-ops 是 MJ System 的运维技能家族 Plugin，提供 4 个 skill：
 - **postgres-prod-lan**: 生产环境 LAN（`${MJ_POSTGRES_PROD_LAN_URL}` 或默认 192.168.0.106:5432）
 - **postgres-prod-wan**: 生产环境 WAN（需配置 `MJ_POSTGRES_PROD_WAN_URL`，无 fallback 默认值）
 
+> **时间戳格式修复 (#38)**：所有 PostgreSQL MCP server 通过 `scripts/pg-server-start.cmd` → `pg-server-wrapper.mjs` 启动，覆盖了 `pg.types` 的 timestamp/timestamptz 解析器（OID 1114/1184），确保查询结果中的时间戳返回 PostgreSQL 原始格式（如 `2026-04-01 16:51:19+08`）而非 node-postgres 默认的 UTC ISO 格式（`2026-04-01T08:51:14.755Z`）。
+
 **SSH（ssh-manager，7 台服务器）：**
 - **CLOUD**: 云服务器 8.135.38.175（需 `SSH_SERVER_CLOUD_PASSWORD`）
 - **RUNNER_LAN / RUNNER_WAN**: Runner 服务器 LAN/WAN（需 `SSH_SERVER_RUNNER_PASSWORD`）
@@ -59,6 +61,11 @@ MCP 服务器需要的密码和连接 URL 通过加密文件管理：
 ## 文件结构
 
 ```
+scripts/
+├── setup-ops-env.ps1         # 秘密值解密 + 环境变量加载
+├── encrypt-ops-secrets.ps1   # 秘密值加密
+├── pg-server-start.cmd       # PG MCP server 启动器（发现 npx 缓存 + 设置 NODE_PATH）
+└── pg-server-wrapper.mjs     # PG timestamp 修复（覆盖 pg.types 解析器）
 skills/
 ├── mj-env-setup/         # 环境搭建技能 + env-reference.md + troubleshooting.md
 ├── mj-env-teardown/      # 环境清理技能

--- a/plugins/mj-ops/scripts/pg-server-start.cmd
+++ b/plugins/mj-ops/scripts/pg-server-start.cmd
@@ -1,0 +1,42 @@
+@echo off
+setlocal enabledelayedexpansion
+REM Bootstrap for @modelcontextprotocol/server-postgres with timestamp fix
+REM Fix #38: Discovers npx cache path, sets NODE_PATH, launches ESM wrapper
+REM
+REM Why this script exists:
+REM   ESM module resolution ignores NODE_PATH, so pg-server-wrapper.mjs
+REM   cannot directly import "pg" from the npx cache. This CMD script
+REM   scans the npx cache directory to find the pg package, then sets
+REM   NODE_PATH so CJS createRequire can resolve it in the wrapper.
+REM
+REM Discovery strategy:
+REM   require.resolve('pg') does NOT work from node -e under npx -p,
+REM   because -e scripts resolve from CWD, not the npx cache.
+REM   Instead we use fs.existsSync to scan npm_config_cache/_npx/
+REM   for the directory containing node_modules/pg — this uses only
+REM   Node.js built-in modules (fs, path) which are always available.
+REM
+REM Usage: pg-server-start.cmd <postgresql-connection-url>
+
+REM Step 1: Install package (if needed) and discover node_modules path
+REM   - npx -y auto-confirms installation
+REM   - 2^>nul suppresses npx stderr (install progress, warnings)
+REM   - fs.existsSync scans npx cache dirs for pg package
+REM   - process.stdout.write outputs ONLY the path (no trailing newline)
+for /f "usebackq tokens=*" %%i in (`npx -y -p @modelcontextprotocol/server-postgres node -e "const fs=require('fs'),path=require('path');const base=path.join(process.env.npm_config_cache,'_npx');const dirs=fs.readdirSync(base);for(const d of dirs){if(fs.existsSync(path.join(base,d,'node_modules','pg'))){process.stdout.write(path.join(base,d,'node_modules'));break}}" 2^>nul`) do set "NODE_PATH=%%i"
+
+if not defined NODE_PATH (
+  echo [pg-wrapper] ERROR: Could not discover npx cache path 1>&2
+  exit /b 1
+)
+
+REM Validate NODE_PATH was not polluted by unexpected npx stdout
+if not exist "%NODE_PATH%\pg" (
+  echo [pg-wrapper] ERROR: NODE_PATH does not contain pg: %NODE_PATH% 1>&2
+  exit /b 1
+)
+
+REM Step 2: Launch the ESM wrapper with resolved NODE_PATH
+REM   %~dp0 resolves to this script's directory (mj-ops/scripts/)
+REM   %* forwards all arguments (connection URL) to the wrapper
+node "%~dp0pg-server-wrapper.mjs" %*

--- a/plugins/mj-ops/scripts/pg-server-wrapper.mjs
+++ b/plugins/mj-ops/scripts/pg-server-wrapper.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+// Wrapper for @modelcontextprotocol/server-postgres
+// Fix #38: override pg type parsers to return raw timestamp strings
+// instead of JS Date objects (which JSON.stringify converts to UTC "Z" format)
+//
+// Mechanism:
+//   1. CJS require("pg") via createRequire — honors NODE_PATH set by pg-server-start.cmd
+//   2. pg.types.setTypeParser overrides OID 1114/1184 to return raw strings
+//   3. CJS and ESM share the same pg module instance (verified: require("pg") === import("pg").default)
+//   4. Dynamic import of server-postgres — its internal pg.Pool uses the overridden parsers
+//
+// Why not ESM import:
+//   ESM bare specifier resolution ignores NODE_PATH and only searches
+//   node_modules/ from the importing file's directory upward. This script
+//   lives in ${CLAUDE_PLUGIN_ROOT}/scripts/, outside the npx cache.
+
+import { createRequire } from "node:module";
+import { pathToFileURL } from "node:url";
+import { dirname, join } from "node:path";
+import { existsSync } from "node:fs";
+
+const require = createRequire(import.meta.url);
+
+try {
+  // 1. Override pg type parsers (CJS require honors NODE_PATH)
+  const pg = require("pg");
+  pg.types.setTypeParser(1114, (val) => val); // timestamp without time zone
+  pg.types.setTypeParser(1184, (val) => val); // timestamp with time zone
+
+  // 2. Derive server-postgres entry path from pg's package.json location
+  //    pg/package.json → <node_modules>/pg/package.json
+  //    dirname twice   → <node_modules>/
+  const pgPkgPath = require.resolve("pg/package.json");
+  const nmBase = dirname(dirname(pgPkgPath));
+  const serverEntry = join(nmBase, "@modelcontextprotocol", "server-postgres", "dist", "index.js");
+
+  if (!existsSync(serverEntry)) {
+    console.error(`[pg-wrapper] ERROR: server-postgres entry not found at ${serverEntry}`);
+    process.exit(1);
+  }
+
+  // 3. Dynamic import of the original server (ESM, file:// URL)
+  await import(pathToFileURL(serverEntry).href);
+} catch (err) {
+  console.error("[pg-wrapper] ERROR:", err.message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Bug 描述

通过 mj-ops 插件的 MCP postgres 工具查询数据库时，所有 `timestamptz` 字段被 node-postgres 转换为 UTC `Z` 格式（如 `2026-04-01T08:51:14.755Z`），而非 PostgreSQL 配置的 `Asia/Shanghai (+08)` 时区格式，导致 ETL 信号表时间戳需人工换算。

## 根因分析

node-postgres (pg) 库默认将 OID 1184 (timestamptz) 和 OID 1114 (timestamp) 解析为 JS Date 对象，JSON.stringify 序列化时转为 UTC ISO 8601 格式。这不是 PostgreSQL 或系统时区的问题，而是客户端解析层的默认行为。

## 修复方案

新增两个脚本，通过 wrapper 模式覆盖 pg 默认的 type parser：

- **`pg-server-start.cmd`** — CMD bootstrap，扫描 npx 缓存目录发现 `node_modules` 路径并设置 `NODE_PATH`
- **`pg-server-wrapper.mjs`** — ESM wrapper，使用 `createRequire`（CJS 解析，尊重 NODE_PATH）加载 pg 模块，调用 `pg.types.setTypeParser(1114/1184, val => val)` 覆盖默认解析器，然后动态导入原始 server-postgres 服务

`.mcp.json` 中 5 个 postgres server 的启动命令从 `npx -y @modelcontextprotocol/server-postgres` 改为 `${CLAUDE_PLUGIN_ROOT}/scripts/pg-server-start.cmd`，连接 URL 参数原样保留。

**关键技术点**：ESM bare specifier 在 npx 外部脚本中无法解析（`ERR_MODULE_NOT_FOUND`），因此使用 CJS `createRequire` 替代 ESM `import`。已验证 CJS `require("pg")` 与 ESM `import("pg").default` 返回同一实例（`===` 为 `true`），确保 type parser 覆盖跨模块生效。

## 影响范围

- **Plugin**: mj-ops
- **MCP Servers**: postgres-dev / postgres-test-lan / postgres-test-wan / postgres-prod-lan / postgres-prod-wan（全部 5 个）
- **不影响**: ssh-manager、pg-aiguide、mj-n8n 插件
- **Skills**: 无需修改（ETL 技能的验证指令是意图导向的，不硬编码时间格式）

## 自检结果

- [x] Bug 已复现并验证修复
- [x] 无引入新的回归问题
- [x] 无残留调试代码
- [x] Commit message 符合规范（仅含 `fix` 类型）
- [x] CHANGELOG.md 已更新（v1.2.4）
