### PR TITLE
fix(mj-ops): add npx cache integrity check to prevent sticky MCP failure (#46)

### DIFF
--- a/plugins/mj-ops/CHANGELOG.md
+++ b/plugins/mj-ops/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 ## [Unreleased]
 
+### Fixed
+- `pg-server-start.cmd` npx 缓存下载中断后留下空目录占位，导致 postgres-* MCP server 永久 `failed` 且无法自愈。新增 6 项关键依赖完整性校验（`pg-types`, `postgres-date` 等），检测损坏时自动清理缓存并重新下载 (#46)
+- `pg-server-wrapper.mjs` 捕获 `MODULE_NOT_FOUND` 错误时输出明确的缓存损坏诊断信息和修复命令 (#46)
+
 ## [1.2.4] - 2026-04-02
 
 ### Fixed

--- a/plugins/mj-ops/scripts/pg-server-start.cmd
+++ b/plugins/mj-ops/scripts/pg-server-start.cmd
@@ -18,6 +18,7 @@ REM   Node.js built-in modules (fs, path) which are always available.
 REM
 REM Usage: pg-server-start.cmd <postgresql-connection-url>
 
+:DISCOVER
 REM Step 1: Install package (if needed) and discover node_modules path
 REM   - npx -y auto-confirms installation
 REM   - 2^>nul suppresses npx stderr (install progress, warnings)
@@ -36,7 +37,30 @@ if not exist "%NODE_PATH%\pg" (
   exit /b 1
 )
 
-REM Step 2: Launch the ESM wrapper with resolved NODE_PATH
+REM Step 2: Dependency integrity check
+REM   Verify critical transitive dependencies have package.json (not just empty dirs).
+REM   npx download interruption can leave empty directories that pass existsSync
+REM   but fail at require() time — a "sticky" failure that never self-heals.
+REM   See: https://github.com/MJ-AgentLab/mj-agentlab-marketplace/issues/46
+set "CACHE_BROKEN="
+for %%D in (pg-types postgres-date postgres-array postgres-bytea postgres-interval pg-connection-string) do (
+    if not exist "%NODE_PATH%\%%D\package.json" set "CACHE_BROKEN=%%D"
+)
+
+if defined CACHE_BROKEN (
+    if defined RETRY_DONE (
+        echo [pg-server] ERROR: npx cache still broken after cleanup — missing !CACHE_BROKEN! 1>&2
+        exit /b 1
+    )
+    echo [pg-server] WARN: Broken npx cache ^(missing !CACHE_BROKEN!\package.json^). Cleaning for re-download... 1>&2
+    set "RETRY_DONE=1"
+    REM Delete the corrupted npx hash directory (parent of node_modules)
+    for /f "delims=" %%P in ("%NODE_PATH%\..") do rd /s /q "%%~fP" 2>nul
+    set "NODE_PATH="
+    goto :DISCOVER
+)
+
+REM Step 3: Launch the ESM wrapper with resolved NODE_PATH
 REM   %~dp0 resolves to this script's directory (mj-ops/scripts/)
 REM   %* forwards all arguments (connection URL) to the wrapper
 node "%~dp0pg-server-wrapper.mjs" %*

--- a/plugins/mj-ops/scripts/pg-server-wrapper.mjs
+++ b/plugins/mj-ops/scripts/pg-server-wrapper.mjs
@@ -42,6 +42,12 @@ try {
   // 3. Dynamic import of the original server (ESM, file:// URL)
   await import(pathToFileURL(serverEntry).href);
 } catch (err) {
+  if (err.code === 'MODULE_NOT_FOUND') {
+    console.error('[pg-wrapper] ERROR: npx cache appears corrupted — missing dependency.');
+    console.error('[pg-wrapper] FIX: Delete the npx cache directory and restart Claude Code:');
+    console.error('  Windows:  rd /s /q "%LOCALAPPDATA%\\npm-cache\\_npx"');
+    console.error('  Unix:     rm -rf "$HOME/.npm/_npx"');
+  }
   console.error("[pg-wrapper] ERROR:", err.message);
   process.exit(1);
 }


### PR DESCRIPTION
## Bug 描述

`/mcp` 面板中 5 个 `plugin:mj-ops:postgres-*` 全部 `failed`，但同插件的 `ssh-manager` 正常。npx 缓存下载中断后留下空目录占位，状态永不自愈。

## 根因分析

`pg-server-start.cmd` 的缓存发现逻辑只检查 `node_modules/pg` 目录是否存在（可达性检查），不验证传递依赖完整性（可用性检查）。当 npx 下载中途中断时，`postgres-date`、`postgres-bytea` 等包目录虽然存在但为空目录（无 `package.json`）。npx 检测到缓存目录已存在则跳过重新下载，导致损坏状态永久持续。

## 修复方案

**双层防御**：

1. **`pg-server-start.cmd`（主动防御）**：在启动 wrapper 前检查 6 个关键传递依赖的 `package.json` 是否存在。检测到损坏时自动删除 npx hash 目录 → goto 重试一次（带 `RETRY_DONE` 防死循环）
2. **`pg-server-wrapper.mjs`（兜底报错）**：在 catch 块中检测 `MODULE_NOT_FOUND` 错误码，输出明确的缓存损坏诊断信息和跨平台修复命令

## 影响范围

- **Plugin**: mj-ops
- **文件**: `scripts/pg-server-start.cmd`, `scripts/pg-server-wrapper.mjs`
- **MCP servers**: postgres-dev, postgres-test-lan, postgres-test-wan, postgres-prod-lan, postgres-prod-wan

## 自检结果
- [x] Bug 已复现并验证修复
- [x] 无引入新的回归问题
- [x] 无残留调试代码
- [x] Commit message 符合规范（仅含 `fix` / `test` / `docs` 类型）
- [x] CHANGELOG.md `[Unreleased]` 区块已更新

Closes #46
