### PR TITLE
feat(mj-sys-doc): register SVL service domain in VALID_DOMAINS (#58)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "mj-sys-doc",
       "source": "./plugins/mj-sys-doc",
       "description": "MJ System 文档工作流技能：规划、编写、校验、迁移、同步、审查",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "author": { "name": "MJ-AgentLab" },
       "category": "productivity",
       "keywords": ["documentation", "markdown", "obsidian", "review", "validation"],

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "mj-sys-doc",
       "source": "./plugins/mj-sys-doc",
       "description": "MJ System 文档工作流技能：规划、编写、校验、迁移、同步、审查",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "author": { "name": "MJ-AgentLab" },
       "category": "productivity",
       "keywords": ["documentation", "markdown", "obsidian", "review", "validation"],

--- a/plugins/mj-sys-doc/.claude-plugin/plugin.json
+++ b/plugins/mj-sys-doc/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mj-sys-doc",
   "description": "MJ System 文档工作流技能家族 - 提供文档规划、编写、校验、迁移、同步和审查能力",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": { "name": "MJ-AgentLab" },
   "repository": "https://github.com/MJ-AgentLab/mj-agentlab-marketplace",
   "license": "MIT",

--- a/plugins/mj-sys-doc/.claude-plugin/plugin.json
+++ b/plugins/mj-sys-doc/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mj-sys-doc",
   "description": "MJ System 文档工作流技能家族 - 提供文档规划、编写、校验、迁移、同步和审查能力",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "author": { "name": "MJ-AgentLab" },
   "repository": "https://github.com/MJ-AgentLab/mj-agentlab-marketplace",
   "license": "MIT",

--- a/plugins/mj-sys-doc/CHANGELOG.md
+++ b/plugins/mj-sys-doc/CHANGELOG.md
@@ -5,6 +5,12 @@
 
 ## [Unreleased]
 
+## [3.0.1] - 2026-04-30
+
+### Fixed
+
+- **`mj-sys-doc-validate` A3 enum check 误报 (#56)** — `parse_frontmatter` 未剥离 YAML quoted scalar 引号，导致 `state: "active"` / `type: "adr"` / `domain: "N8N"` 等合法 frontmatter 都被检查为字面值（含引号）→ 与 `VALID_STATES` / `VALID_TYPES` / `VALID_DOMAINS` 比较后报 FAIL。修复后引号自动剥离，所有 v5.0 合法文档恢复 A3 PASS（验证：mj-system 仓 ADR-001 ~ ADR-006 + STANDARD/SPEC/GUIDE 文档全部通过）
+
 ## [3.0.0] - 2026-04-25
 
 ### Breaking Changes

--- a/plugins/mj-sys-doc/CHANGELOG.md
+++ b/plugins/mj-sys-doc/CHANGELOG.md
@@ -5,6 +5,12 @@
 
 ## [Unreleased]
 
+## [3.0.2] - 2026-04-30
+
+### Added
+
+- **`SVL` 服务域注册到 `validate_doc.py:VALID_DOMAINS` (#58)** — 与已登记的 `QVL`（QueryVolumeLoader）平行，支持 mj-system #173 引入的新 SubmitVolumeLoader 服务（biz/ops 双域）。修复后 `[SPEC]_SVL_*.md` / `[ADR]_003_*.md`（重命名后）等文档 frontmatter `domain: "SVL"` 不再误报 A3 FAIL。
+
 ## [3.0.1] - 2026-04-30
 
 ### Fixed

--- a/plugins/mj-sys-doc/skills/mj-sys-doc-validate/scripts/validate_doc.py
+++ b/plugins/mj-sys-doc/skills/mj-sys-doc-validate/scripts/validate_doc.py
@@ -102,6 +102,21 @@ A6_ALLOWLIST_PATTERNS = [
 # Helpers
 # ---------------------------------------------------------------------------
 
+def _strip_yaml_quotes(value: str) -> str:
+    """Strip one matching pair of surrounding double or single quotes from a YAML scalar.
+
+    YAML quoted scalars (`"active"`, `'active'`) and plain scalars (`active`) all denote
+    the same string `active` after parsing. This helper normalizes the two quoted forms
+    so downstream enum/equality checks (A2/A3) compare against the unquoted value.
+
+    Mismatched / unbalanced quotes are left untouched (defensive — prefer over-quoting
+    surfacing as FAIL than silently rewriting unexpected input).
+    """
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+        return value[1:-1]
+    return value
+
+
 def parse_frontmatter(lines: list[str]) -> tuple[dict[str, str], int]:
     """Extract YAML frontmatter fields (shallow key: value) and return end line index."""
     if not lines or lines[0].strip() != "---":
@@ -117,7 +132,7 @@ def parse_frontmatter(lines: list[str]) -> tuple[dict[str, str], int]:
             current_key = m.group(1)
             value = line[m.end():].strip()
             if value:
-                fields[current_key] = value
+                fields[current_key] = _strip_yaml_quotes(value)
             else:
                 fields[current_key] = ""
         elif current_key and stripped.startswith("- "):

--- a/plugins/mj-sys-doc/skills/mj-sys-doc-validate/scripts/validate_doc.py
+++ b/plugins/mj-sys-doc/skills/mj-sys-doc-validate/scripts/validate_doc.py
@@ -27,7 +27,7 @@ OPTIONAL_FIELDS = {"tags", "aliases", "supersedes"}
 
 VALID_STATES = {"draft", "active", "deprecated"}
 VALID_TYPES = {"guide", "spec", "standard", "adr", "runbook", "postmortem", "issue", "assessment"}
-VALID_DOMAINS = {"AEC", "DQV", "QVL", "QCM", "SAC", "FC", "DOCKER", "DB", "FLYWAY", "N8N", "CICD", "GIT", "NET", "SYS"}
+VALID_DOMAINS = {"AEC", "DQV", "QVL", "SVL", "QCM", "SAC", "FC", "DOCKER", "DB", "FLYWAY", "N8N", "CICD", "GIT", "NET", "SYS"}
 
 ADR_DECISIONS = {"accepted", "superseded", "rejected"}
 ISSUE_RESOLUTIONS = {"open", "fixed", "wontfix", "obsolete"}


### PR DESCRIPTION
## 变更摘要

注册 `SVL`（SubmitVolumeLoader）服务域到 `validate_doc.py` 的 `VALID_DOMAINS` 集合，与已登记的 `QVL`（QueryVolumeLoader）平行。

mj-system 项目通过 `#173` / PR `#174` 完成 CRV → SVL 服务重命名（per ADR-006），引入新 biz/ops 域服务 SubmitVolumeLoader。其 SPEC 文档与 ADR-003（重命名后）frontmatter 使用 `domain: "SVL"`，当前 `VALID_DOMAINS` 未登记导致 A3 误报。

> 注：此问题在 [#56] quote-stripping 修复（PR #57）合并前被 quote bug 掩盖。本 PR 基于 `bugfix/56-validate-doc-yaml-quotes` 分支链式构建（version bump 接续 3.0.1 → 3.0.2）。**本 PR 必须在 [#57] 之后合并**，否则版本号冲突。

Resolves: #58
Depends on: #57

## 影响范围

- **Plugin**: `mj-sys-doc` 3.0.1 → **3.0.2**（patch — 1-line 注册表增量）
- **Skill**: `mj-sys-doc-validate`
- **同步更新**: `plugin.json` + `marketplace.json` 版本号；`CHANGELOG.md` `[3.0.2]` Added 条目

**下游解锁**：mj-system PR #174 中以下文档恢复 A3 PASS（之前 FAIL "domain 'SVL' not in [...]"）：
- `docs/design/SubmitVolume/[SPEC]_SVL_Loader_Service.md`
- `docs/design/SubmitVolume/[SPEC]_SVL_ODS_DWD_Schema.md`
- `docs/adr/[ADR]_003_CRV_ODS_to_DWD_Unified_Design.md`（命名 deprecated 但 domain 切 SVL）

## 审核要点

1. **`VALID_DOMAINS` 中 `"SVL"` 的位置** — 放在 `"QVL"` 之后（service abbreviations 区段），保持已有的"服务缩写在前 / 基础设施缩写居中 / SYS 在末尾"的视觉聚簇
2. **版本 bump 的链式约束** — `3.0.1 → 3.0.2` 假定 #57 先合并；若 #57 还未合并就 review 本 PR，请理解 plugin.json/marketplace.json 的 diff 中包含 #57 的 `3.0.0 → 3.0.1` 历史
3. **CHANGELOG `[3.0.2]` 条目语义** — 标记为 `Added`（注册新值即添加）；条目同时引用 mj-system 重命名背景

## 自检结果

- [x] plugin.json 字段完整（仅版本号变更）
- [x] SKILL.md frontmatter 有效（无 SKILL.md 改动）
- [x] 无硬编码（仅 1 个 string literal `"SVL"` 加入集合，符合现有 `VALID_DOMAINS` 风格）
- [x] 无残留调试代码
- [x] Commit message 符合 `<type>(<scope>): <summary>` 规范（`feat(mj-sys-doc)` — feature/* 矩阵允许 `feat`）
- [x] CHANGELOG.md `[Unreleased]` 区块已更新（实写为 `[3.0.2] - 2026-04-30`，因为 patch bump 同 PR 完成）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
