### PR TITLE
fix(plugins): repository field must be string per plugin manifest schema

### DIFF
--- a/plugins/learn-kit/.claude-plugin/plugin.json
+++ b/plugins/learn-kit/.claude-plugin/plugin.json
@@ -6,10 +6,7 @@
     "name": "MJ-AgentLab",
     "url": "https://github.com/MJ-AgentLab"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/MJ-AgentLab/mj-agentlab-marketplace"
-  },
+  "repository": "https://github.com/MJ-AgentLab/mj-agentlab-marketplace",
   "license": "MIT",
   "keywords": ["learning", "pedagogy", "methodology", "rule-list", "interpretation", "discovery", "locate", "scan", "three-tier", "foundation", "structural", "challenge", "ai-generation", "html-render"],
   "skills": "./skills/"

--- a/plugins/notebooklm-kit/.claude-plugin/plugin.json
+++ b/plugins/notebooklm-kit/.claude-plugin/plugin.json
@@ -5,10 +5,7 @@
   "author": {
     "name": "ranzuozhou"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/MJ-AgentLab/mj-agentlab-marketplace"
-  },
+  "repository": "https://github.com/MJ-AgentLab/mj-agentlab-marketplace",
   "license": "MIT",
   "keywords": [
     "notebooklm",


### PR DESCRIPTION
## Summary

Both `plugins/learn-kit/.claude-plugin/plugin.json` and `plugins/notebooklm-kit/.claude-plugin/plugin.json` had `repository` written as the npm-style `{ type, url }` object. Claude Code plugin manifest schema accepts only the string form, so `/plugin` install failed with:

```
Validation errors: repository: Invalid input: expected string, received object
```

Per [plugins-reference docs](https://code.claude.com/docs/en/plugins-reference), `repository` must be a string (e.g. `"https://github.com/user/plugin"`). Both files updated to the string form.

## Why both plugins

Only learn-kit triggered the user-visible failure (that's what they tried to install), but notebooklm-kit had the identical object-form bug and would fail the same way next install. Fixing in one PR.

## Scope

- **Manifest-only fix** — no behavior changes, no skill changes, no MCP changes.
- **No version bump** — old version had no installable cached copy, so cache-consistency is a non-issue. Plugins remain at `learn-kit@0.3.0` and `notebooklm-kit@2.4.1`.
- **No CHANGELOG entry** — too small/non-functional to warrant one; can be folded into the next minor's changelog if desired.

## Test plan

- [x] Both `plugin.json` files remain valid JSON (`node -e "JSON.parse(...)"` ✓)
- [ ] After merge: `/plugin` → Discover → learn-kit → Install succeeds without schema error
- [ ] After merge: same for notebooklm-kit
- [ ] CI marketplace plugin structure check passes (does not depend on `repository` shape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)