### PR TITLE
infra(scripts): commit-validation tooling hardening — projectize PR #102 post-mortem (P0+P1)

### DIFF
--- a/.claude/skills/mp-flow-self-review/SKILL.md
+++ b/.claude/skills/mp-flow-self-review/SKILL.md
@@ -70,7 +70,7 @@ Locate linked artifacts:
 | 5 | 文档同步检查 (4 子项 5a/5b/5c/5d) | 见下 |
 | 6 | AC 都有验证证据 (指向 Stage 6 dogfood) | AC 验证 |
 | 7 | 无应排除文件 (PR_BODY.md 临时 / IDE 缓存 / .env / *.key) | git diff filter |
-| 8 | commit message 符合 `<type>(<scope>): <summary>` | `[STANDARD]_Commit_Message_Convention` (post-PR 2) |
+| 8 | **(强制)** 跑 `sh scripts/validate-commits.sh origin/<base>..HEAD`；输出粘到「本地验证」段；0 failures 才放行 | `[STANDARD]_Commit_Message_Convention` §3 / §4 / §11 |
 | 9 | PR template 自检 6 项满足 | `.github/PULL_REQUEST_TEMPLATE/<type>.md` |
 | 10 | 是否触发 release.yml (`VERSION` 文件变更) → 是则必 HITL 确认发布意图 | §3.1 #10 |
 | 11 | 涉及 secret / 凭据 → 必停 | §3.1 #9 |

--- a/.claude/skills/mp-git-commit/SKILL.md
+++ b/.claude/skills/mp-git-commit/SKILL.md
@@ -170,6 +170,26 @@ EOF
 
 不用 `--no-verify` / 不绕过 pre-commit hook。
 
+### Step 8 — Post-commit PATTERN Self-check (v1.1+ NEW)
+
+立即跑 `scripts/validate-commits.sh HEAD~1..HEAD`（或多 commit 时 `HEAD~N..HEAD`）验证刚写的 commit subject 通过 PATTERN。
+
+```bash
+# 单 commit 自检
+sh scripts/validate-commits.sh HEAD~1..HEAD
+
+# 多 commit 自检（N = 本次 batch 数量）
+sh scripts/validate-commits.sh HEAD~N..HEAD
+```
+
+**期望**：`[OK] N commit(s) validated; 0 failures`
+
+**如失败**：脚本输出会明确指出违规 commit + 具体原因 + 修正建议（type 不在 enum / scope 不在 whitelist / summary > 72 chars 等）。立即用 `git commit --amend` (单 commit) 或 `git rebase -i HEAD~N --reword` (多 commit) 修正——**不要等 push / CI 才发现**。
+
+参考：[`docs/rule/[STANDARD]_Commit_Message_Convention.md`](../../../docs/rule/[STANDARD]_Commit_Message_Convention.md) §11 Common Mistakes（4 个典型失败模式 + remediation）。
+
+只在 Step 8 通过后才进入 Stage 8 push 阶段（移交给 `/mp-git-push`）。
+
 ## Output Format
 
 ```markdown

--- a/.claude/skills/mp-git-push/SKILL.md
+++ b/.claude/skills/mp-git-push/SKILL.md
@@ -13,7 +13,7 @@ Pushes a marketplace branch to GitHub origin after running a 7-item pre-push saf
 
 **Workflow position**: Stage 8 step 2 of HITL Prompt 11-stage flow.
 
-## Pre-Push Checklist (7 items)
+## Pre-Push Checklist (8 items)
 
 | # | Check | How | Block? |
 |---|---|---|---|
@@ -24,8 +24,11 @@ Pushes a marketplace branch to GitHub origin after running a 7-item pre-push saf
 | 5 | 无 > 10 MB 大文件 | `git ls-tree -r HEAD --long | awk '$4>10485760'` | YES |
 | 6 | 与 origin 同分支无 conflict（首次 push 跳） | `git log @{u}..HEAD` 看 ahead；`git log HEAD..@{u}` 看 behind | WARN |
 | 7 | 与 base 分支没有意外 diverge | `git log origin/develop..HEAD --oneline` 行数合理 | WARN |
+| 8 | **Commit message PATTERN 合规** (v1.1+ NEW) | `sh scripts/validate-commits.sh origin/<base>..HEAD` 返回 0 failures | **YES** |
 
 任一 BLOCK → STOP；WARN → 提示用户确认。
+
+**Item 8 详解**：跑标准化的 `scripts/validate-commits.sh`（CI 同源 PATTERN regex；catches `chore` type / `docs` as scope / summary > 72 chars / 其他格式错误）。FAIL 时脚本输出会精确指出违规 commit + 修正建议（`git rebase -i --reword` / cherry-pick 重建）。FAIL 必须修复后才允许 push——pre-push hook（如已装）也会拦截，但本 checklist 项确保 skill 主动检查不依赖 hook。参考 [`docs/rule/[STANDARD]_Commit_Message_Convention.md`](../../../docs/rule/[STANDARD]_Commit_Message_Convention.md) §11 Common Mistakes。
 
 ## Workflow
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`scripts/validate-commits.{sh,ps1}`** — bulk validator for marketplace commit subjects. Dual-language (bash + PowerShell) parity; same interface, exit codes, output formatting. Reads PATTERN verbatim from existing canonical source. Per-commit failure output diagnoses specific reason (type / scope / length) + targeted suggestion (e.g., «'chore' is NOT in marketplace's 7-type enum; use 'docs', 'refactor', or 'infra'»; «'docs' is a TYPE not a SCOPE; pick 'docs-rule' / 'docs-adr' / etc»). Closes the gap that caused PR #102 closure + rebuild (4 commit subjects violated PATTERN: 3 used scope `docs` + 1 used `chore` type + 1 exceeded 72-char summary).
+
+- **`scripts/install-hooks.ps1`** extended with **pre-push hook installer** (alongside existing commit-msg). The pre-push hook delegates to `scripts/validate-commits.sh` (single source of validation logic) — catches violations introduced via `git commit --amend` / `git cherry-pick` / `git rebase` that bypass commit-msg. Opt-in (re-run installer to activate); zero impact on contributors who don't.
+
+### Changed
+
+- **`docs/rule/[STANDARD]_Commit_Message_Convention.md` v1.0 → v1.1** — add §11 «Common Mistakes (post-v4.5.0 lessons)» documenting 4 failure patterns: (§11.1) `chore` type rejected with substitution table; (§11.2) `docs` is a TYPE not a SCOPE; (§11.3) summary > 72 chars with CJK / symbols; (§11.4) documentation/* template recommendation vs CI hook reality; (§11.5) local validation workflow. §9.3 Future CI Gates updated to reference new validator. Frontmatter revision block added. Backward compatible — PATTERN regex unchanged.
+
+- **`docs/guide/[GUIDE]_Marketplace_Agent_Execution_Checklist.md`** — Stage 8 (Commit/Push/PR) Actions段 + Verification checklist 加入 push 前必跑 `scripts/validate-commits.{sh,ps1}` 的强制项。Runtime entry point now naturally flows through the validator.
+
+- **`.claude/skills/mp-git-commit/SKILL.md`** — NEW Step 8 «Post-commit PATTERN Self-check» after Step 7 Execute. Runs `sh scripts/validate-commits.sh HEAD~N..HEAD` immediately to catch violations before handoff to mp-git-push.
+
+- **`.claude/skills/mp-git-push/SKILL.md`** — Pre-Push Checklist 7 → 8 items. NEW item 8 «Commit message PATTERN 合规» (BLOCK on fail). Mandatory regardless of pre-push git-hook install state.
+
+- **`.claude/skills/mp-flow-self-review/SKILL.md`** — Item 8 strengthened from vague «commit message 符合 …» to mandate running `validate-commits.sh` + pasting output to «本地验证» segment; 0 failures gate the stage exit.
+
+### Notes
+
+- No `VERSION` bump — pure tooling + docs; zero plugin behavior change for end-users.
+- 4-layer defense net now in place: (1) commit-msg hook per-commit at commit time; (2) mp-git-commit Step 8 per-batch right after commit; (3) mp-flow-self-review item 8 at pre-PR-review; (4) mp-git-push checklist item 8 + optional pre-push hook at push time. CI «Validate Structure» is the final safety net (unchanged).
+- 4 sites of PATTERN regex now (install-hooks.ps1 + ci.yml + STANDARD §3+§4 + validate-commits.{sh,ps1}); single-source consolidation tracked as future P2 refactor.
+
 ## [4.5.0] - 2026-05-18
 
 ### Changed

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -28,7 +28,7 @@ Navigation hub for all marketplace documentation.
 | Document | State | Version | Purpose |
 |----------|-------|---------|---------|
 | [Documentation Framework](./rule/[STANDARD]_Documentation_Framework.md) | active | v1.5 | 6 tag prefixes + 8-field frontmatter + 3-state machine + 路径稳定性 + INDEX sync + flat archive layout（v1.4）+ §1 exemption cancellation（v1.5）|
-| [Commit Message Convention](./rule/[STANDARD]_Commit_Message_Convention.md) | active | v1.0 | `<type>(<scope>): <summary>` + 7 types + marketplace scope whitelist + branch-type matrix |
+| [Commit Message Convention](./rule/[STANDARD]_Commit_Message_Convention.md) | active | v1.1 | `<type>(<scope>): <summary>` + 7 types + marketplace scope whitelist + branch-type matrix + §11 Common Mistakes (post-v4.5.0 lessons + scripts/validate-commits.{sh,ps1} workflow) |
 | [GitHub Markdown](./rule/[STANDARD]_GitHub_Markdown.md) | active | v1.0 | ATX headings + GFM tables + native alerts + frontmatter syntax for GitHub web |
 | [AI Engineering Execution HITL Prompt](./rule/[STANDARD]_AI_Engineering_Execution_HITL_Prompt.md) | active | v1.4 | 11 阶段闭环 + skill 矩阵 + HITL 触发规则 + universal skeleton §0（v1.4 marketplace 独立性原则）|
 

--- a/docs/guide/[GUIDE]_Marketplace_Agent_Execution_Checklist.md
+++ b/docs/guide/[GUIDE]_Marketplace_Agent_Execution_Checklist.md
@@ -265,6 +265,7 @@ related:
 - 不 stage PR_BODY.md / 临时文件 / 个人配置
 - commit message: `<type>(<scope>): <summary>` + multi-line body 解释 why
 - Co-Authored-By 行加在 commit message 尾（如 AI 协作）
+- **Push 前必跑 `scripts/validate-commits.sh`**（或 `.ps1`）— 验证全 batch commit subjects 通过 PATTERN；FAIL 必须 amend / rebase 修复后才 push
 - Push: `git push -u origin <branch>`
 - PR：`gh pr create --base develop --head <branch> --title "..." --body-file PR_BODY.md`
 - PR_BODY.md 临时文件 push 后 `rm`（不 commit）
@@ -273,6 +274,7 @@ related:
 **Verification**：
 - [ ] commit 拆分合理（按 logical group）
 - [ ] commit message 符合规范
+- [ ] **`scripts/validate-commits.sh origin/<base>..HEAD` 返回 0 failures**（详见 `[STANDARD]_Commit_Message_Convention` §11.5）
 - [ ] 无 secret / 大文件 / 临时调试文件被 stage
 - [ ] PR 创建成功（拿到 PR URL）
 - [ ] PR_BODY.md 临时文件已删除

--- a/docs/rule/[STANDARD]_Commit_Message_Convention.md
+++ b/docs/rule/[STANDARD]_Commit_Message_Convention.md
@@ -1,12 +1,12 @@
 ---
 type: standard
 scope: marketplace
-summary: Commit message format v1.0 — type(scope) header, 7 types, marketplace scope whitelist, branch-type matrix
+summary: Commit message format v1.1 — type(scope) header, 7 types, marketplace scope whitelist, branch-type matrix, §11 common mistakes from v4.5.0 post-mortem
 owner: marketplace-maintainers
 created: 2026-05-15
-updated: 2026-05-15
+updated: 2026-05-18
 state: active
-version: v1.0
+version: v1.1
 domain: governance
 tags:
   - commit
@@ -16,7 +16,10 @@ related:
   - ./[STANDARD]_Documentation_Framework.md
   - ./[STANDARD]_GitHub_Markdown.md
   - ./[STANDARD]_AI_Engineering_Execution_HITL_Prompt.md
-  - ../CONTRIBUTING.md
+  - ../guide/[GUIDE]_Contributing.md
+revision: |
+  2026-05-18 — v1.1: §11 Common Mistakes 新章（4 个 v4.5.0 后失败模式 + remediation）；companion scripts/validate-commits.{sh,ps1} + install-hooks.ps1 pre-push hook + 3 skill integrations（mp-git-commit / mp-git-push / mp-flow-self-review）；§9.3 Future CI Gates 更新指向新脚本；PATTERN regex 无变化（向后兼容）
+  2026-05-15 — v1.0: Initial canonical commit convention
 ---
 
 # [STANDARD] Commit Message Convention
@@ -213,10 +216,79 @@ Before pushing, run `git log --oneline -5` and inspect:
 
 ### §9.3 Future CI Gates
 
-v1.1+ may add `.github/workflows/commit-lint.yml` that runs commitlint or equivalent against new commits per PR. Currently the convention is documented-only.
+v1.1 added standalone batch validator: `scripts/validate-commits.{sh,ps1}` (callable from CLI, mp-* skills, and pre-push hook). v1.2+ may add a `.github/workflows/comment-on-pr.yml` bot that posts per-commit failure details as PR comments (deferred — see P2 in v1.1 post-mortem). Current CI (`.github/workflows/ci.yml` `Validate Structure` job) already enforces PATTERN on every PR.
+
+## §11 Common Mistakes (post-v4.5.0 lessons)
+
+These 4 patterns caught real PRs — PR #102 was closed for exactly these violations before successful PR #103 rebuild. Each is now diagnosed automatically by `scripts/validate-commits.{sh,ps1}` with a targeted suggestion.
+
+### §11.1 `chore` type rejected
+
+Conventional Commits 1.0 defines `chore`, but marketplace's §3 enum does **not** include it. The 7 allowed types are: `feat | fix | perf | refactor | test | docs | infra`.
+
+Substitution guide:
+- Documentation-only changes (incl. deletes / renames / archive of docs): `docs(<scope>): ...`
+- Restructuring without behavior change: `refactor(<scope>): ...`
+- Build / CI / scripts / dependencies: `infra(<scope>): ...`
+
+Bad: `chore(docs-adr): archive old exemption-review ADR`
+Good: `docs(docs-adr): archive old exemption-review ADR`
+
+### §11.2 `docs` is a TYPE not a SCOPE
+
+A common mistake: using `docs` as the scope name. The canonical doc-related scopes per §4 are: `docs-rule` / `docs-adr` / `docs-guide` / `docs-runbook` / `docs-spec` — pick based on which `docs/` subdirectory is being edited.
+
+Bad: `refactor(docs): rename CONTRIBUTING.md to ...`
+Good: `refactor(docs-guide): rename CONTRIBUTING.md to ...`
+
+If the change spans multiple `docs/` subdirs, use `docs(marketplace): ...` (broader marketplace-wide scope).
+
+### §11.3 Summary > 72 chars (Chinese + symbols count as 1 char each)
+
+PATTERN `.{1,72}` counts every grapheme regardless of byte width:
+- `§` = 1 char (not 2 despite UTF-8 being 2 bytes)
+- `→` = 1 char
+- Each CJK character = 1 char
+- Combining accents = 1 char each
+
+Tip: when mixing Chinese / symbols, target 50-60 char summary to leave headroom.
+
+Bad (75 chars): `feat(docs-rule): HITL STANDARD v1.3 -> v1.4 §0 Universal Skeleton + 内化 generic HITL workflow`
+Good (64 chars): `feat(docs-rule): HITL STANDARD v1.3 -> v1.4 §0 universal skeleton internalization`
+
+### §11.4 `documentation/*` branch PR template recommendation vs CI hook reality
+
+The `.github/PULL_REQUEST_TEMPLATE/documentation.md` self-check item 8 suggests «documentation/* branches use only `docs` type». This is a **stylistic recommendation**, not a hook-enforced rule. CI's PATTERN accepts the wider type set (`feat`/`refactor`/`infra`/etc.) on any branch.
+
+Reviewers may choose stricter convention during PR review (e.g., asking for `docs(marketplace): ...` instead of `feat(marketplace): ...` on a documentation/* branch). CI will **not** auto-reject for type-vs-branch-type mismatch.
+
+If unsure, prefer the more specific semantic type (`feat` for new file, `refactor` for restructuring, `chore` → use `docs`/`refactor`/`infra` per §11.1).
+
+### §11.5 Local validation before push (highly recommended)
+
+Run `scripts/validate-commits.{sh,ps1}` **before** `git push`:
+
+```bash
+./scripts/validate-commits.sh                       # default: origin/develop..HEAD
+./scripts/validate-commits.sh origin/main..HEAD     # custom range
+```
+
+```powershell
+pwsh ./scripts/validate-commits.ps1
+```
+
+Catches violations BEFORE CI rejection — saves the close-PR / delete-branch / cherry-pick rebuild cycle (~30 min on a real failure batch).
+
+Alternative: install the pre-push hook once (auto-validates every push):
+```powershell
+pwsh ./scripts/install-hooks.ps1
+```
+
+This installs both `commit-msg` (per-commit validation at commit time) and `pre-push` (batch validation at push time) hooks. The latter catches violations introduced via `git commit --amend` / `git cherry-pick` / `git rebase` that bypass `commit-msg`.
 
 ## §10 Change History
 
 | Version | Date | Summary |
 |---------|------|---------|
+| v1.1 | 2026-05-18 | Add §11 Common Mistakes — 4 v4.5.0 failure patterns documented + remediation (chore type rejected / docs as type-not-scope / 72-char summary with CJK / branch-template vs CI reality / local validation workflow). Companion: scripts/validate-commits.{sh,ps1} + install-hooks.ps1 pre-push hook + 3 skill integrations (mp-git-commit Step 8 / mp-git-push 8th checklist item / mp-flow-self-review item 8). §9.3 updated to point to new validator. Backward compatible — PATTERN regex unchanged. |
 | v1.0 | 2026-05-15 | Initial canonical commit convention. Extracted + expanded from `docs/CONTRIBUTING.md` § 提交规范. Replaces stale legacy `*-sys-*` scope whitelist with marketplace v4.x scopes (`learn-kit`, `marketplace`, `docs-*`, `release` etc.). Adopted in PR #75 (v4.2.0). Preserves Conventional Commits 1.0 base + 7-type enum; marketplace-specific 12-item scope whitelist. |

--- a/scripts/install-hooks.ps1
+++ b/scripts/install-hooks.ps1
@@ -3,8 +3,13 @@
     Install git hooks for mj-agentlab-marketplace
 
 .DESCRIPTION
-    Installs commit-msg hook that validates commit message format.
-    Format: <type>(<scope>): <summary>
+    Installs two hooks:
+      1. commit-msg — validates a SINGLE commit subject at commit time
+         (inline PATTERN regex; legacy)
+      2. pre-push   — validates ALL about-to-push commit subjects in
+         batch by delegating to scripts/validate-commits.sh (catches
+         violations introduced via amend / cherry-pick / rebase that
+         bypassed commit-msg, AND batches that aren't caught one-by-one)
 
     Handles both regular .git directory and bare repo + worktree
     setup (where .git is a pointer file).
@@ -70,9 +75,76 @@ fi
 
 Set-Content -Path $HookFile -Value $HookContent -Encoding UTF8 -NoNewline
 
+# ============================================================================
+# pre-push hook — batch validation via scripts/validate-commits.sh
+# ============================================================================
+$PrePushFile = Join-Path $HooksDir "pre-push"
+
+$PrePushContent = @'
+#!/bin/sh
+# pre-push hook: validate ALL about-to-push commit subjects in batch.
+# Delegates to scripts/validate-commits.sh — single source of validation logic
+# (so PATTERN never drifts between hooks and the standalone validator).
+#
+# git pre-push stdin format (one line per ref):
+#   <local ref> <local sha> <remote ref> <remote sha>
+# For a brand-new branch (no remote yet), <remote sha> is 0000000000...
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+VALIDATOR="$REPO_ROOT/scripts/validate-commits.sh"
+
+if [ ! -x "$VALIDATOR" ] && [ ! -r "$VALIDATOR" ]; then
+  # Script missing — skip hook (don't block push). User likely on an
+  # older revision pre-dating this hook installer.
+  exit 0
+fi
+
+ZERO='0000000000000000000000000000000000000000'
+EXIT=0
+
+while read -r LOCAL_REF LOCAL_SHA REMOTE_REF REMOTE_SHA; do
+  # Skip deletions (local sha = 0)
+  if [ "$LOCAL_SHA" = "$ZERO" ]; then
+    continue
+  fi
+
+  if [ "$REMOTE_SHA" = "$ZERO" ]; then
+    # New branch — validate against upstream develop as fallback base.
+    # Use 3-dot to find the merge-base implicitly.
+    RANGE="origin/develop..$LOCAL_SHA"
+  else
+    # Existing branch — validate only the newly added commits
+    RANGE="$REMOTE_SHA..$LOCAL_SHA"
+  fi
+
+  # Run validator; if it exits non-zero, fail the push
+  sh "$VALIDATOR" "$RANGE"
+  if [ $? -ne 0 ]; then
+    EXIT=1
+  fi
+done
+
+if [ $EXIT -ne 0 ]; then
+  echo ""
+  echo "pre-push hook: validation failed. To bypass (NOT recommended):"
+  echo "  git push --no-verify"
+  echo "Better: fix the offending commit(s) per the suggestions above, then re-push."
+fi
+
+exit $EXIT
+'@
+
+Set-Content -Path $PrePushFile -Value $PrePushContent -Encoding UTF8 -NoNewline
+
 Write-Host "Installed commit-msg hook to: $HookFile" -ForegroundColor Green
+Write-Host "Installed pre-push  hook to: $PrePushFile" -ForegroundColor Green
 Write-Host ""
 Write-Host "Validation format: <type>(<scope>): <summary>" -ForegroundColor White
 Write-Host "  Types:  feat | fix | perf | refactor | test | docs | infra" -ForegroundColor White
 Write-Host "  Scopes (v4.x): learn-kit | marketplace | ci | scripts | deps | infra | docs-rule | docs-adr | docs-guide | docs-runbook | docs-spec | release" -ForegroundColor White
 Write-Host "  Canonical: docs/rule/[STANDARD]_Commit_Message_Convention.md" -ForegroundColor White
+Write-Host ""
+Write-Host "Hook semantics:" -ForegroundColor White
+Write-Host "  commit-msg : validates 1 commit subject inline (PATTERN duplicated in hook)" -ForegroundColor White
+Write-Host "  pre-push   : validates ALL push-range commits via scripts/validate-commits.sh" -ForegroundColor White
+Write-Host "               (batch check; catches amend/cherry-pick/rebase slips)" -ForegroundColor White

--- a/scripts/validate-commits.ps1
+++ b/scripts/validate-commits.ps1
@@ -1,0 +1,135 @@
+<#
+.SYNOPSIS
+    Bulk validator for marketplace commit subjects (PowerShell parity for validate-commits.sh).
+
+.DESCRIPTION
+    Validates commit message subjects in a given git range against the canonical
+    PATTERN regex. PATTERN is kept in sync with scripts/install-hooks.ps1 +
+    .github/workflows/ci.yml + docs/rule/[STANDARD]_Commit_Message_Convention.md
+    §3 / §4. Single-source consolidation is tracked as a future P2 refactor;
+    for now, 4 sites must match.
+
+.PARAMETER Range
+    Git range to validate. Default: origin/develop..HEAD
+
+.EXAMPLE
+    pwsh .\scripts\validate-commits.ps1
+    pwsh .\scripts\validate-commits.ps1 origin/main..HEAD
+    pwsh .\scripts\validate-commits.ps1 HEAD~5..HEAD
+
+.OUTPUTS
+    Exit code 0 = all pass; 1 = >= 1 failure.
+#>
+
+param(
+    [string]$Range = "origin/develop..HEAD"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# Force UTF-8 console output so '§' and Chinese suggestion text render correctly
+# on Windows PowerShell hosts where default encoding may be cp936 / cp1252.
+try {
+    [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+    $OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+} catch {
+    # Older PS hosts may not allow this; non-fatal — fall through with default encoding
+}
+
+# Canonical PATTERN — verbatim from install-hooks.ps1 line 52 + ci.yml line 32
+$Pattern = '^(feat|fix|perf|refactor|test|docs|infra)\((learn-kit|marketplace|ci|scripts|deps|infra|docs-rule|docs-adr|docs-guide|docs-runbook|docs-spec|release)\): .{1,72}$'
+$AllowedTypes = 'feat | fix | perf | refactor | test | docs | infra'
+$AllowedScopes = 'learn-kit | marketplace | ci | scripts | deps | infra | docs-rule | docs-adr | docs-guide | docs-runbook | docs-spec | release'
+$AllowedTypesRegex = '^(feat|fix|perf|refactor|test|docs|infra)$'
+$AllowedScopesRegex = '^(learn-kit|marketplace|ci|scripts|deps|infra|docs-rule|docs-adr|docs-guide|docs-runbook|docs-spec|release)$'
+
+# Fetch commits in range (skip merges per CI convention)
+# Wrap in @(...) to force array (PowerShell deflates single-line output to scalar string)
+$Lines = @(& git log --no-merges --format='%H%x09%s' $Range 2>$null)
+if (-not $Lines -or $Lines.Count -eq 0) {
+    Write-Host "validate-commits: no commits in range '$Range' (or range invalid)"
+    exit 0
+}
+
+$Total = 0
+$Failed = 0
+$FailEntries = @()
+
+foreach ($Line in $Lines) {
+    if ([string]::IsNullOrWhiteSpace($Line)) { continue }
+    $Parts = $Line -split "`t", 2
+    if ($Parts.Count -lt 2) { continue }
+    $Sha = $Parts[0]
+    $Subject = $Parts[1]
+    $Total++
+
+    if ($Subject -match $Pattern) {
+        continue
+    }
+
+    $Failed++
+    $Short = $Sha.Substring(0, 7)
+    $Reasons = New-Object System.Collections.Generic.List[string]
+
+    # Reason 1: type not in allowed enum
+    if ($Subject -match '^([a-z]+)\(') {
+        $Type = $Matches[1]
+        if ($Type -notmatch $AllowedTypesRegex) {
+            $Reasons.Add("        Reason: type '$Type' not in allowed enum")
+            $Reasons.Add("                Allowed: $AllowedTypes")
+            if ($Type -eq 'chore') {
+                $Reasons.Add("                Suggest: 'chore' is NOT in marketplace's 7-type enum; use 'docs', 'refactor', or 'infra'")
+            }
+        }
+    }
+
+    # Reason 2: scope not in whitelist
+    if ($Subject -match '^[a-z]+\(([^)]+)\):') {
+        $Scope = $Matches[1]
+        if ($Scope -notmatch $AllowedScopesRegex) {
+            $Reasons.Add("        Reason: scope '$Scope' not in allowed whitelist")
+            $Reasons.Add("                Allowed: $AllowedScopes")
+            if ($Scope -eq 'docs') {
+                $Reasons.Add("                Suggest: 'docs' is a TYPE not a SCOPE; pick 'docs-rule' / 'docs-adr' / 'docs-guide' / 'docs-runbook' / 'docs-spec' based on which subdir you're editing")
+            }
+        }
+    }
+
+    # Reason 3: summary length (after ": ")
+    if ($Subject -match '^[a-z]+\([^)]+\): (.*)$') {
+        $Summary = $Matches[1]
+        $Len = $Summary.Length
+        if ($Len -gt 72) {
+            $Over = $Len - 72
+            $Reasons.Add("        Reason: summary length $Len chars > 72 limit")
+            $Reasons.Add("                (PATTERN .{1,72} counts every char; Chinese / § / → each = 1 char)")
+            $Reasons.Add("                Suggest: shorten by $Over chars; aim <= 60 when mixing Chinese for safety margin")
+        }
+    }
+
+    # Fallback if no specific reason detected
+    if ($Reasons.Count -eq 0) {
+        $Reasons.Add("        Reason: subject does not match overall '<type>(<scope>): <summary>' format")
+        $Reasons.Add("                Check: leading lowercase type, parens around scope, ': ' separator (colon + space), non-empty summary")
+    }
+
+    $Entry = "  FAIL  $Short  $Subject`n" + ($Reasons -join "`n")
+    $FailEntries += $Entry
+}
+
+# Final report
+if ($Failed -eq 0) {
+    Write-Host "[OK] $Total commit(s) validated in range '$Range'; 0 failures"
+    exit 0
+}
+
+Write-Host "[FAIL] $Failed of $Total commit(s) failed PATTERN validation in range '$Range'"
+foreach ($Entry in $FailEntries) {
+    Write-Host ""
+    Write-Host $Entry
+}
+Write-Host ""
+Write-Host "See docs/rule/[STANDARD]_Commit_Message_Convention.md §3 / §4 / §11 for canonical whitelists + common-mistakes guidance."
+Write-Host "Fix locally before push: 'git rebase -i <base> --reword <commit>' OR cherry-pick onto fresh branch."
+exit 1

--- a/scripts/validate-commits.sh
+++ b/scripts/validate-commits.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+# validate-commits.sh — bulk validator for marketplace commit subjects
+#
+# Synopsis:
+#   ./scripts/validate-commits.sh                       # default range: origin/develop..HEAD
+#   ./scripts/validate-commits.sh origin/main..HEAD     # custom range
+#   ./scripts/validate-commits.sh HEAD~5..HEAD          # last 5 commits
+#
+# Exit code: 0 = all pass; 1 = >=1 failure
+#
+# PATTERN is kept in sync with scripts/install-hooks.ps1 + .github/workflows/ci.yml
+# + docs/rule/[STANDARD]_Commit_Message_Convention.md §3 / §4. Single-source
+# consolidation is tracked as a future P2 refactor; for now, 4 sites must match.
+
+set -u
+
+RANGE="${1:-origin/develop..HEAD}"
+
+# Canonical PATTERN — verbatim from install-hooks.ps1 line 52 + ci.yml line 32
+PATTERN='^(feat|fix|perf|refactor|test|docs|infra)\((learn-kit|marketplace|ci|scripts|deps|infra|docs-rule|docs-adr|docs-guide|docs-runbook|docs-spec|release)\): .{1,72}$'
+ALLOWED_TYPES='feat | fix | perf | refactor | test | docs | infra'
+ALLOWED_SCOPES='learn-kit | marketplace | ci | scripts | deps | infra | docs-rule | docs-adr | docs-guide | docs-runbook | docs-spec | release'
+
+# Fetch commits in range (skip merges per CI convention)
+COMMITS=$(git log --no-merges --format='%H%x09%s' "$RANGE" 2>/dev/null || true)
+if [ -z "$COMMITS" ]; then
+  echo "validate-commits: no commits in range '$RANGE' (or range invalid)"
+  exit 0
+fi
+
+TOTAL=0
+FAILED=0
+FAIL_OUTPUT=""
+
+# Process each commit; portable while-read (works in /bin/sh + bash + git-bash)
+while IFS=$(printf '\t') read -r SHA SUBJECT; do
+  [ -z "$SHA" ] && continue
+  TOTAL=$((TOTAL + 1))
+
+  if echo "$SUBJECT" | grep -qE "$PATTERN"; then
+    continue
+  fi
+
+  FAILED=$((FAILED + 1))
+  SHORT="$(echo "$SHA" | cut -c1-7)"
+
+  # Diagnose failure reason(s)
+  REASONS=""
+  # Reason 1: type not in allowed enum (parse leading word before paren)
+  TYPE=$(echo "$SUBJECT" | sed -E 's/^([a-z]+)\(.*$/\1/')
+  if ! echo "$TYPE" | grep -qE '^(feat|fix|perf|refactor|test|docs|infra)$'; then
+    REASONS="$REASONS\n        Reason: type '$TYPE' not in allowed enum"
+    REASONS="$REASONS\n                Allowed: $ALLOWED_TYPES"
+    if [ "$TYPE" = "chore" ]; then
+      REASONS="$REASONS\n                Suggest: 'chore' is NOT in marketplace's 7-type enum; use 'docs', 'refactor', or 'infra'"
+    fi
+  fi
+  # Reason 2: scope not in whitelist (parse between parens)
+  SCOPE=$(echo "$SUBJECT" | sed -E 's/^[a-z]+\(([^)]+)\):.*$/\1/')
+  if [ -n "$SCOPE" ] && [ "$SCOPE" != "$SUBJECT" ]; then
+    if ! echo "$SCOPE" | grep -qE '^(learn-kit|marketplace|ci|scripts|deps|infra|docs-rule|docs-adr|docs-guide|docs-runbook|docs-spec|release)$'; then
+      REASONS="$REASONS\n        Reason: scope '$SCOPE' not in allowed whitelist"
+      REASONS="$REASONS\n                Allowed: $ALLOWED_SCOPES"
+      if [ "$SCOPE" = "docs" ]; then
+        REASONS="$REASONS\n                Suggest: 'docs' is a TYPE not a SCOPE; pick 'docs-rule' / 'docs-adr' / 'docs-guide' / 'docs-runbook' / 'docs-spec' based on which subdir you're editing"
+      fi
+    fi
+  fi
+  # Reason 3: summary length (after ": ")
+  SUMMARY=$(echo "$SUBJECT" | sed -E 's/^[a-z]+\([^)]+\): //')
+  if [ -n "$SUMMARY" ] && [ "$SUMMARY" != "$SUBJECT" ]; then
+    LEN=$(printf '%s' "$SUMMARY" | wc -m | tr -d ' ')
+    if [ "$LEN" -gt 72 ]; then
+      REASONS="$REASONS\n        Reason: summary length $LEN chars > 72 limit"
+      REASONS="$REASONS\n                (PATTERN .{1,72} counts every char; Chinese / § / → each = 1 char)"
+      REASONS="$REASONS\n                Suggest: shorten by $((LEN - 72)) chars; aim ≤ 60 when mixing Chinese for safety margin"
+    fi
+  fi
+  # Fallback if no specific reason detected (e.g., missing parens, leading space, weird format)
+  if [ -z "$REASONS" ]; then
+    REASONS="\n        Reason: subject does not match overall '<type>(<scope>): <summary>' format"
+    REASONS="$REASONS\n                Check: leading lowercase type, parens around scope, ': ' separator (colon + space), non-empty summary"
+  fi
+
+  FAIL_OUTPUT="$FAIL_OUTPUT\n  FAIL  $SHORT  $SUBJECT$REASONS\n"
+done <<EOF
+$COMMITS
+EOF
+
+# Final report
+PASSED=$((TOTAL - FAILED))
+if [ "$FAILED" -eq 0 ]; then
+  echo "[OK] $TOTAL commit(s) validated in range '$RANGE'; 0 failures"
+  exit 0
+fi
+
+echo "[FAIL] $FAILED of $TOTAL commit(s) failed PATTERN validation in range '$RANGE'"
+printf "%b" "$FAIL_OUTPUT"
+echo ""
+echo "See docs/rule/[STANDARD]_Commit_Message_Convention.md §3 / §4 / §11 for canonical whitelists + common-mistakes guidance."
+echo "Fix locally before push: 'git rebase -i <base> --reword <commit>' OR cherry-pick onto fresh branch."
+exit 1


### PR DESCRIPTION
## 变更摘要

Projectize PR #102 post-mortem learning (4 commit-subject violations that caused CI failure → close-PR + delete-branch + cherry-pick rebuild cycle, ~30 min remediation cost). Personal memory `[[feedback_validate_commit_format_locally]]` already saved as patch — this PR makes the same protection **available to all contributors (humans + AI agents)** via project-level codification.

**P0 + P1** from user post-mortem proposal (6 items, 6 commits, 11 files):

| # | Hash | Commit |
|---|------|--------|
| 1 | `1e60bd1` | feat(scripts): add validate-commits.{sh,ps1} dual-language commit subject validator |
| 2 | `98a1b2e` | feat(scripts): install-hooks.ps1 add pre-push hook installer |
| 3 | `e07966e` | docs(docs-rule): Commit_Message_Convention v1.0 -> v1.1 add 11 Common Mistakes |
| 4 | `f5a3aac` | docs(docs-guide): Checklist Stage 8 add validate-commits step |
| 5 | `20d2011` | refactor(marketplace): integrate validate-commits.sh into 3 skills (commit/push/self-review) |
| 6 | `8634d17` | docs(marketplace): CHANGELOG + INDEX sync for commit-validation tooling hardening |

**Statistics**: 11 files changed (2 new + 9 edit); +443 / −10 lines. No VERSION bump (pure tooling, zero plugin user impact).

## 影响评估

**受影响**：
- ✅ Marketplace contributors (humans) — get a callable `scripts/validate-commits.{sh,ps1}` to run before push; can install pre-push hook via `pwsh scripts/install-hooks.ps1` for automatic enforcement
- ✅ AI agents using `/mp-git-commit` / `/mp-git-push` / `/mp-flow-self-review` skills — now automatically invoke the validator (no more reliance on session-personal memory)
- ✅ CI pipeline (`.github/workflows/ci.yml`) — **NOT changed** (P2 out of scope); existing PATTERN check unchanged

**Not affected**:
- Plugin runtime behavior (no plugin code touched)
- VERSION (stays 4.5.0)
- marketplace.json / plugin.json (no metadata change)
- release.yml (no auto-trigger; no main merge)
- End users of installed plugins (zero visible change)

## 审核要点

1. **PATTERN parity**: confirm the regex in `scripts/validate-commits.{sh,ps1}` matches verbatim the regex in `scripts/install-hooks.ps1` line 52 + `.github/workflows/ci.yml` line 32 + `docs/rule/[STANDARD]_Commit_Message_Convention.md` §3+§4. (4 sites now; future P2 candidate: collapse to single source.)

2. **Self-dogfood**: the new `validate-commits.sh` validated its own 6 PR commits with **6/6 PASS** before push. If reviewer wants to verify: `sh scripts/validate-commits.sh origin/develop..HEAD` on this branch.

3. **STANDARD v1.0 → v1.1 backward compatibility**: only ADDS §11 (new content); §1-§10 unchanged structurally; PATTERN regex unchanged → existing commits / hooks / CI unaffected.

4. **Skill integration consistency**: all 3 skills point to same validator + same STANDARD §11; no skill-specific PATTERN regex hardcoded.

5. **Hook idempotency**: `pwsh scripts/install-hooks.ps1` is safe to re-run; overwrites both `commit-msg` (existing behavior) and new `pre-push` hook.

## 自检结果

- [x] 配置文件语法正确（2 个 shell scripts + 1 PowerShell + 5 markdown 文件; markdownlint clean）
- [x] CI/CD 流水线不受影响（`.github/workflows/ci.yml` 未改; 现有 `Validate Structure` job 继续按原 PATTERN 校验，与新脚本一致）
- [x] 无硬编码敏感信息（PATTERN regex 公开; 无 token / secret）
- [x] Commit message 符合规范 — **6/6 commits 通过新 validator 自检**（types: feat / docs / refactor; scopes: scripts / docs-rule / docs-guide / marketplace; summaries 均 ≤72 chars; **dogfood-validated**）

## 本地验证 (per HITL STANDARD §4.8 双段)

```text
$ git log --oneline origin/develop..HEAD | nl
     1  8634d17 docs(marketplace): CHANGELOG + INDEX sync for commit-validation tooling hardening
     2  20d2011 refactor(marketplace): integrate validate-commits.sh into 3 skills (commit/push/self-review)
     3  f5a3aac docs(docs-guide): Checklist Stage 8 add validate-commits step
     4  e07966e docs(docs-rule): Commit_Message_Convention v1.0 -> v1.1 add 11 Common Mistakes
     5  98a1b2e feat(scripts): install-hooks.ps1 add pre-push hook installer
     6  1e60bd1 feat(scripts): add validate-commits.{sh,ps1} dual-language commit subject validator

$ sh scripts/validate-commits.sh origin/develop..HEAD
[OK] 6 commit(s) validated in range 'origin/develop..HEAD'; 0 failures

$ pwsh -NoProfile -Command "& './scripts/validate-commits.ps1' 'origin/develop..HEAD'"
[OK] 6 commit(s) validated in range 'origin/develop..HEAD'; 0 failures

# FAIL path verified via reflog (PR #102's old chore commit reachable)
$ sh scripts/validate-commits.sh d1a624e~1..d1a624e
[FAIL] 1 of 1 commit(s) failed PATTERN validation in range 'd1a624e~1..d1a624e'

  FAIL  d1a624e  chore(docs-adr): archive old exemption-review ADR + delete 7 superseded files
        Reason: type 'chore' not in allowed enum
                Allowed: feat | fix | perf | refactor | test | docs | infra
                Suggest: 'chore' is NOT in marketplace's 7-type enum; use 'docs', 'refactor', or 'infra'

# Hook installation verified
$ pwsh scripts/install-hooks.ps1
Installed commit-msg hook to: <bare-worktree>/hooks/commit-msg
Installed pre-push  hook to: <bare-worktree>/hooks/pre-push
```

## AI 自检 (per HITL STANDARD §4.8 12-item checklist)

1. **改动是否完全对应 Plan**: ✅ 严格按 Phase 1-7 计划；P0 + P1 全部完成；P2 (CI bot + error-msg suggest) 明示 deferred 到下一 PR
2. **是否超出 scope**: ✅ no scope creep (ci.yml / VERSION / marketplace.json / plugin.json 均未改)
3. **是否改变 plugin API / SKILL description / allowed-tools / marketplace.json schema**: ⚠️ 3 个 mp-* skill SKILL.md body 改动（NOT frontmatter；no description / allowed-tools / disable-model-invocation 字段变更）
4. **是否有 hardcode / secret / 绝对路径 / 调试代码**: ✅ 0 hits
5a-d. **文档同步检查**: ✅ 反向扫描 / 新文档创建 / INDEX-CLAUDE-CHANGELOG sync / Plugin Delta Check 全部勾选
6. **AC 是否都有验证证据**: ✅ Self-dogfood 6/6 PASS + FAIL path 用 reflog 验证 + hook 安装实测
7. **是否有不应提交文件**: ⚠️ PR_BODY.md — push 后立即 rm
8. **commit message 格式**: ✅ 6/6 自验证 PASS (validate-commits.sh)
9. **PR template 自检 6 项**: 见上述「自检结果」段
10. **是否触发 release.yml**: ✅ NO (VERSION unchanged)
11. **涉及 secret / 凭据**: ✅ 0 hits
12. **Doc Framework 合规**: ✅ STANDARD v1.0 → v1.1 仅加 §11 + revision block; no archive trigger (< 50% rewrite); /mp-doc-validate 应过

## 风险与回滚

- **风险 1**: validator script bug (false positive / false negative) — **缓解**: self-dogfood + FAIL-path test 都过；4 sites PATTERN parity 已 review
- **风险 2**: PowerShell encoding 问题（'§' 显示为 '??') — **缓解**: 已 force UTF-8 OutputEncoding；测试通过；ASCII status markers ([OK]/[FAIL]) cross-environment 安全
- **风险 3**: pre-push hook 误拒 valid push — **缓解**: hook delegate 到 .sh 单源逻辑；hook 安装 opt-in；可 `git push --no-verify` 绕过（hook 自身打印此提示，标注 NOT recommended）
- **回滚**: 6 commits 任一可 `git revert` 单独撤回；整 PR `git revert <merge-commit>`

## 关联

- Builds on: PR #103 (v4.5.0 Framework v1.5) + PR #104 (independence audit cleanup) — both merged
- Companion memory: `[[feedback_validate_commit_format_locally]]` (personal, session-bootstrap)
- Closes (informally): user's post-mortem proposal in conversation (no GitHub issue)
- Deferred to next PR: P2.4.1 (CI error «suggest fix» enhancement) + P2.4.2 (PR-comment-bot workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
