### PR TITLE
fix: README + CLAUDE.md drift post-v4.5.0 + ci.yml badge guard

### DIFF
--- a/.claude/skills/mp-doc-bump-version/SKILL.md
+++ b/.claude/skills/mp-doc-bump-version/SKILL.md
@@ -1,22 +1,30 @@
 ---
 name: mp-doc-bump-version
-description: Bumps marketplace versions atomically across all version-bearing files — `VERSION`, `.claude-plugin/marketplace.json` (metadata.version + plugins[].version per plugin), `plugins/<name>/.claude-plugin/plugin.json` (version), and aligns CHANGELOG entries (top-level + per-plugin) by promoting `[Unreleased]` to `[X.Y.Z]` with date. Make sure to use this skill whenever the user says "bump version", "升版本", "版本号 bump", "marketplace patch / minor / major", "plugin bump", "version sync", "Stage 8 / release-prep version", "VERSION update", "bump marketplace", "bump learn-kit", "release prep", or when preparing a release PR (release/v<X.Y.Z>) or any change that warrants version increment per `[GUIDE]_Version_Management`. Calls `scripts/bump-version.ps1` if it exists (uses its semantics); otherwise performs the equivalent edits directly. Enforces version triangle invariants: `VERSION` ↔ `marketplace.json metadata.version` ↔ each `plugin.json version` ↔ `marketplace.json plugins[entry].version`. Outputs the proposed version transitions + ready commands; does NOT auto-execute — user reviews. Do not use for: tag creation (release.yml automates after PR merge to main), CHANGELOG content authoring (use the existing CHANGELOG semantics; this skill only structurally promotes [Unreleased] → [X.Y.Z]), or non-version metadata updates.
+description: Bumps marketplace versions atomically across all version-bearing files — `VERSION`, `.claude-plugin/marketplace.json` (metadata.version + plugins[].version per plugin), `plugins/<name>/.claude-plugin/plugin.json` (version), `README.md` badge (line 3) + plugin table version cell, `CLAUDE.md` plugin line, and aligns CHANGELOG entries (top-level + per-plugin) by promoting `[Unreleased]` to `[X.Y.Z]` with date. Make sure to use this skill whenever the user says "bump version", "升版本", "版本号 bump", "marketplace patch / minor / major", "plugin bump", "version sync", "Stage 8 / release-prep version", "VERSION update", "bump marketplace", "bump learn-kit", "release prep", or when preparing a release PR (release/v<X.Y.Z>) or any change that warrants version increment per `[GUIDE]_Version_Management`. Calls `scripts/bump-version.ps1` if it exists (uses its semantics); otherwise performs the equivalent edits directly. Enforces version triangle invariants: `VERSION` ↔ `marketplace.json metadata.version` ↔ each `plugin.json version` ↔ `marketplace.json plugins[entry].version`. Outputs the proposed version transitions + ready commands; does NOT auto-execute — user reviews. Do not use for: tag creation (release.yml automates after PR merge to main), CHANGELOG content authoring (use the existing CHANGELOG semantics; this skill only structurally promotes [Unreleased] → [X.Y.Z]), or non-version metadata updates.
 ---
 
 # Marketplace Doc Bump Version
 
 ## Overview
 
-Atomically bumps versions across the marketplace's 4 version sites and aligns CHANGELOG headers. Enforces the version triangle invariant.
+Atomically bumps versions across the marketplace's 5 version sites and aligns CHANGELOG headers. Enforces the version quintangle invariant.
 
-**Version Triangle**:
+**Version Quintangle (5-site invariant)**:
 
 ```text
 VERSION (root file)
    ↕
 .claude-plugin/marketplace.json metadata.version
-   ↕
-plugins/<name>/.claude-plugin/plugin.json version  ↔  .claude-plugin/marketplace.json plugins[<name>].version
+   ↕                              ↘
+plugins/<name>/.claude-plugin/plugin.json version  ←→  .claude-plugin/marketplace.json plugins[<name>].version
+   ↕                                                                    ↕
+README.md badge (L3) + plugin-table version cell    ←→    CLAUDE.md `plugins/` learn-kit line
+
+# Why 5 sites (post-v4.5.0 lesson):
+# v4.4.9 / v4.4.10 / v4.4.11 / v4.5.0 manual bumps skipped scripts/bump-version.ps1,
+# leaving README badge stuck at 4.4.8 + plugin table cell at 1.1.0 + CLAUDE.md learn-kit
+# line at v1.0.0 across 4 successive releases. CI now guards README badge (ci.yml step
+# "Validate README badge matches VERSION"); CLAUDE.md remains manual-discipline.
 ```
 
 **Reference**: [[../../../docs/guide/[GUIDE]_Version_Management|Version Management]] + [[../../../scripts/bump-version.ps1|bump-version.ps1]] (if exists).
@@ -151,23 +159,36 @@ Per-plugin `plugins/<name>/CHANGELOG.md`: same pattern。
 
 Date: 用 `Get-Date -Format yyyy-MM-dd` 取本地日期，目前是 `2026-05-15`。
 
-## Step 7: Verify Version Triangle
+## Step 7: Verify Version Quintangle
 
 ```bash
-# 三角一致性
+# 5-site 一致性 (post-v4.5.0 expanded from triangle)
 v_root=$(cat VERSION)
 v_mp_meta=$(jq -r '.metadata.version' .claude-plugin/marketplace.json)
 v_plugin_in_mp=$(jq -r '.plugins[] | select(.name=="learn-kit") | .version' .claude-plugin/marketplace.json)
 v_plugin_self=$(jq -r '.version' plugins/learn-kit/.claude-plugin/plugin.json)
 
+# NEW: README + CLAUDE.md sites (use sed for portability; grep -P locale-sensitive on Windows git-bash)
+v_readme_badge=$(sed -n 's/.*badge\/version-\([0-9.]\+\)-.*/\1/p' README.md | head -1)
+v_readme_plugin_cell=$(grep -oE '\*\*[0-9.]+\*\*' README.md | head -1 | tr -d '*')
+v_claude_plugin_line=$(grep -oE 'learn-kit` v[0-9.]+' CLAUDE.md | head -1 | sed 's/^learn-kit` v//')
+
 echo "VERSION = $v_root"
 echo "marketplace.json metadata = $v_mp_meta"
 echo "marketplace.json plugins[learn-kit] = $v_plugin_in_mp"
 echo "learn-kit plugin.json = $v_plugin_self"
+echo "README.md badge = $v_readme_badge"
+echo "README.md plugin table = $v_readme_plugin_cell"
+echo "CLAUDE.md learn-kit = $v_claude_plugin_line"
 
 [ "$v_root" = "$v_mp_meta" ] && echo "marketplace OK" || echo "MISMATCH: VERSION ≠ metadata"
 [ "$v_plugin_in_mp" = "$v_plugin_self" ] && echo "learn-kit OK" || echo "MISMATCH: plugins[].version ≠ plugin.json.version"
+[ "$v_readme_badge" = "$v_root" ] && echo "README badge OK" || echo "MISMATCH: README badge ≠ VERSION"
+[ "$v_readme_plugin_cell" = "$v_plugin_self" ] && echo "README plugin OK" || echo "MISMATCH: README plugin cell ≠ plugin.json"
+[ "$v_claude_plugin_line" = "$v_plugin_self" ] && echo "CLAUDE OK" || echo "MISMATCH: CLAUDE.md learn-kit ≠ plugin.json"
 ```
+
+> CI also enforces README badge ↔ VERSION via the `Validate README badge matches VERSION` step in `.github/workflows/ci.yml` (added 2026-05-18). CLAUDE.md remains manual-discipline (no static-pattern script can reliably parse + replace the prose plugin line).
 
 ## Output Format
 
@@ -238,11 +259,12 @@ jq '.plugins[] | select(.name=="learn-kit") | .version' .claude-plugin/marketpla
 
 ## Anti-patterns
 
-- **不要** 仅改一个版本字段（必同步全 4 个）
+- **不要** 仅改一个版本字段（必同步全 5 sites: VERSION + marketplace.json metadata + marketplace.json plugins[] + plugin.json + README.md badge / plugin cell + CLAUDE.md plugin line）
 - **不要** Major bump 自主推进（§3.1 #7 必 HITL）
 - **不要** 跳 CHANGELOG promote（release.yml 抽 release notes 时会出错）
 - **不要** 手工 git tag（release.yml 自动）
 - **不要** 改 plugin.json 字段以外的 plugin metadata（用 `/mp-flow-author`）
+- **不要** 漏掉 README badge / plugin-table cell / CLAUDE.md plugin line bump — `bump-version.ps1` 已 cover README badge + table cell (line 65 marketplace scope; string-replace based); CLAUDE.md plugin line 是 manual (script 不 pattern-match prose plugin line)。**postmortem**: v4.4.9 → v4.5.0 4 个 release 连续漏掉 README + CLAUDE.md, silent drift 直到用户截图发现; CI guard 已加，但 skill 用户仍应自检 5 sites
 
 ## Handoff to Next Stage
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,6 +199,30 @@ jobs:
           [ $ERRORS -gt 0 ] && exit 1
           echo "All versions consistent"
 
+      - name: Validate README badge matches VERSION
+        # Guards against the silent badge drift that produced the v4.4.8-stuck-while-on-v4.5.0
+        # postmortem (last 4 release bumps skipped scripts/bump-version.ps1; README never synced).
+        # Single-line check: README.md line 3 must encode the same X.Y.Z as VERSION.
+        run: |
+          FILE_VERSION=$(cat VERSION | tr -d '[:space:]')
+          README_VERSION=$(grep -oP 'badge/version-\K[0-9]+\.[0-9]+\.[0-9]+' README.md | head -1)
+
+          if [ -z "$README_VERSION" ]; then
+            echo "ERROR: README.md doesn't contain a version badge matching pattern 'badge/version-X.Y.Z'"
+            echo "Expected line 3 form: ![Version](https://img.shields.io/badge/version-X.Y.Z-blue)"
+            exit 1
+          fi
+
+          if [ "$FILE_VERSION" != "$README_VERSION" ]; then
+            echo "ERROR: README.md badge ($README_VERSION) != VERSION ($FILE_VERSION)"
+            echo ""
+            echo "Fix options:"
+            echo "  1. Edit README.md line 3 — replace 'version-${README_VERSION}-blue' with 'version-${FILE_VERSION}-blue'"
+            echo "  2. Or run: pwsh ./scripts/bump-version.ps1 -From ${README_VERSION} -To ${FILE_VERSION}"
+            exit 1
+          fi
+          echo "OK: README badge matches VERSION ($FILE_VERSION)"
+
       - name: Validate CHANGELOG presence
         run: |
           ERRORS=0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,18 @@
 
 ## [Unreleased]
 
-_(no in-flight changes at release-cut time)_
+### Fixed
+
+- **`README.md`** — refresh stale content post-v4.5.0: badge `4.4.8` → `4.5.0`; learn-kit plugin-table cell `1.1.0` → `1.2.0`; fix **5 broken links** (3× `docs/MIGRATION_GUIDE.md` → `docs/guide/[GUIDE]_Migration_From_v3_to_v4.md` + 2× `docs/CONTRIBUTING.md` → `docs/guide/[GUIDE]_Contributing.md`; both moved by PR #103). **Root cause**: last 4 release-bump commits (v4.4.9 / v4.4.10 / v4.4.11 / v4.5.0) skipped `scripts/bump-version.ps1` so README never got version sync.
+- **`CLAUDE.md`** — refresh stale content post-v4.5.0: learn-kit `v1.0.0` → `v1.2.0` mention; `docs/` Project Structure line rewritten to reflect 5-subdir structure + renamed migration guide path; Documentation Framework heading adds `当前 v1.5 / marketplace v4.5.0` suffix + STANDARD list shows v1.5 / v1.1 versions; docs/ tree drops `CONTRIBUTING.md` + `MIGRATION_GUIDE.md` from exempt line (only `INDEX.md` exempt per Framework v1.5 §1 special clause), converts «PR 3 / PR 4 (will move)» future-tense to completion-state, adds `archive/` flat layout line; `MIGRATION_GUIDE.md` link in v4.0.0 Restructure Note → renamed path; HITL STANDARD reference `(v1.2)` → `(v1.4)`; «历史版本记录» fills 4.0.0 → 4.5.0 gap with v4.1.0 + v4.2.0 + v4.3.x-4.4.11 + v4.5.0 entries.
+
+### Added
+
+- **`.github/workflows/ci.yml`** — NEW step «Validate README badge matches VERSION» appended after «Validate version consistency». Guards against the silent badge drift that produced the v4.4.8-stuck-while-on-v4.5.0 postmortem. Fails CI if `README.md` line 3 badge encodes a different `X.Y.Z` than the `VERSION` file. Error output suggests both manual-edit fix + `bump-version.ps1` command. Runs on all PRs + branch pushes (no `release/*` skip).
+
+### Changed
+
+- **`.claude/skills/mp-doc-bump-version/SKILL.md`** — promote «Version Triangle (4-site)» → «Version Quintangle (5-site invariant)»: add README.md badge + plugin-table cell + CLAUDE.md plugin line. Frontmatter description extends version-bearing-files list. Step 7 Verify adds 3 new sed-based checks (cross-platform: `grep -P` is locale-sensitive on Windows git-bash) + cross-references ci.yml's new CI guard. Anti-patterns expand "4 sites" → "5 sites" + add explicit 4-release silent-drift postmortem note.
 
 ## [4.5.0] - 2026-05-18
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,11 +5,11 @@
 ## Project Structure
 
 - `plugins/` — **1 个通用插件**（v4.0.0 起整合）：
-  - `learn-kit` v1.0.0（教学方法论 + AI 三档生成 + 交互式 HTML + nlm-studio NLM 多媒体生成；v4.0.0 起吸收 notebooklm-kit 的核心多媒体场景）
-- `scripts/` — 基础设施脚本（bump-version, install-hooks, clone-bare）
+  - `learn-kit` v1.2.0（教学方法论 + AI 三档生成 + 交互式 HTML + nlm-studio NLM 多媒体生成；v4.0.0 起吸收 notebooklm-kit 的核心多媒体场景；v1.2.0 起 plugin 内教学文档合并为 2 份 [GUIDE]）
+- `scripts/` — 基础设施脚本（bump-version, install-hooks, validate-commits, clone-bare）
 - `.claude-plugin/marketplace.json` — 市场元数据（版本 + 插件注册表）
 - `VERSION` — 市场整体版本号（权威源）
-- `docs/` — 项目文档（见 [INDEX.md](docs/INDEX.md)），含 [MIGRATION_GUIDE.md](docs/MIGRATION_GUIDE.md) + ADR
+- `docs/` — 项目文档（见 [INDEX.md](docs/INDEX.md)），含 rule / guide / runbook / adr / spec 5 子目录 + 迁移指引 [docs/guide/[GUIDE]_Migration_From_v3_to_v4.md](docs/guide/[GUIDE]_Migration_From_v3_to_v4.md)
 
 ## Key Conventions
 
@@ -45,25 +45,26 @@
 - 模板 / references / scripts 放在 skill 目录内部
 - 不使用 `components` 字段（auto-discovery 标准）
 
-## Documentation Framework (v4.2.0 起)
+## Documentation Framework (v4.2.0 起；当前 v1.5 / marketplace v4.5.0)
 
 marketplace 文档体系遵循以下三层 STANDARD（位于 `docs/rule/`）:
 
-- **[Documentation Framework](docs/rule/[STANDARD]_Documentation_Framework.md)** — 6 tag prefixes（STANDARD/ADR/GUIDE/RUNBOOK/SPEC/POSTMORTEM）+ 8-field frontmatter + 3-state machine + path stability + INDEX sync
-- **[Commit Message Convention](docs/rule/[STANDARD]_Commit_Message_Convention.md)** — `<type>(<scope>): <summary>` + 7 types + marketplace scope whitelist + branch-type matrix
+- **[Documentation Framework](docs/rule/[STANDARD]_Documentation_Framework.md)** v1.5 — 6 tag prefixes（STANDARD/ADR/GUIDE/RUNBOOK/SPEC/POSTMORTEM）+ 8-field frontmatter + 3-state machine + path stability + INDEX sync；v1.5 起取消 §1 豁免机制，保留 5 类 community/external-spec exclusion
+- **[Commit Message Convention](docs/rule/[STANDARD]_Commit_Message_Convention.md)** v1.1 — `<type>(<scope>): <summary>` + 7 types + marketplace scope whitelist + branch-type matrix + §11 Common Mistakes
 - **[GitHub Markdown](docs/rule/[STANDARD]_GitHub_Markdown.md)** — ATX headings + GFM tables + native alerts + frontmatter syntax
 
-文档目录子结构（PR 3 retrofit 后所有现有 tag-prefixed 文档全部归位）:
+文档目录子结构（v4.5.0 起所有 tag-prefixed 文档已归位 + flat archive layout）:
 
 ```
 docs/
-├── INDEX.md / CONTRIBUTING.md / MIGRATION_GUIDE.md   # 豁免 frontmatter
-├── rule/        — STANDARDs (3 in v4.2.0)
-├── guide/       — GUIDEs (4 will move here in PR 3)
-├── runbook/     — RUNBOOKs (1 will move here in PR 3)
-├── adr/         — ADRs (2 will move; ADR-LearnKit moves to plugin in PR 4)
+├── INDEX.md            # 唯一豁免 frontmatter (Framework v1.5 §1 INDEX special clause)
+├── rule/        — STANDARDs (Framework / Commit / GitHub Markdown / HITL Prompt 4 active)
+├── guide/       — GUIDEs (含 [GUIDE]_Contributing + [GUIDE]_Migration_From_v3_to_v4 自 v4.5.0 起)
+├── runbook/     — RUNBOOKs
+├── adr/         — ADRs (v4.5.0 加 Exemption Reversal；ADR-LearnKit 在 plugin 内)
 ├── spec/        — SPECs (2 seeds in v4.2.0)
 ├── postmortem/  — empty placeholder
+├── archive/     — flat layout (Framework v1.4 §2.3.5；`[DEPRECATED]_[TAG]_*_vX.Y.md` 命名)
 └── _templates/  — 6 templates (TEMPLATE_{STANDARD,ADR,GUIDE,RUNBOOK,SPEC,POSTMORTEM}.md)
 ```
 
@@ -79,7 +80,7 @@ Templates 与 mp-doc-author skill 协作起草新文档；mp-doc-validate skill 
 - **改** `/learn-kit:generate-tier` 工作流 8-step → 10-step：HTML 渲染（step 8）后加 optional step 9 询问是否调 nlm-studio（默认 skip，opt-in）；原 step 9 (Summary) 改名 step 10
 - **bump** learn-kit `0.3.1 → 1.0.0`（major：新增 MCP 依赖 + 首个 stable 版本）；marketplace `3.2.1 → 4.0.0`（major：删插件 + 跟随 v3.0.0 删 5 个插件先例）
 - 决策记录：[docs/adr/[ADR]_NotebookLM_Kit_Retirement.md](docs/adr/[ADR]_NotebookLM_Kit_Retirement.md)
-- 用户迁移：[docs/MIGRATION_GUIDE.md](docs/MIGRATION_GUIDE.md) §v3.2.x → v4.0.0
+- 用户迁移：[docs/guide/[GUIDE]_Migration_From_v3_to_v4.md](docs/guide/[GUIDE]_Migration_From_v3_to_v4.md) §v3.2.x → v4.0.0
 
 **Plugin Secrets Management**：v4.0.0 无 secrets 配置需求。learn-kit 的 nlm-studio 通过 `notebooklm-mcp` MCP server 直接调用，认证使用 NotebookLM OAuth（用户在终端 `nlm login` 一次完成）；其余 4 个 skill 纯静态模板 / 本地文件操作，无凭据。
 
@@ -90,12 +91,16 @@ Templates 与 mp-doc-author skill 协作起草新文档；mp-doc-validate skill 
 - **v3.2.0**（2026-05-13）：learn-kit v0.2.0 → v0.3.0；新增 generate-tier AI 三档生成 + 交互式 HTML；learn-kit 主动与 notebooklm-kit 解绑
 - **v3.2.1**（2026-05-14）：plugin.json `repository` schema 修正
 - **v4.0.0**（2026-05-14）：notebooklm-kit 退场 + nlm-studio 吸收到 learn-kit；marketplace 收敛到 1 个 plugin
+- **v4.1.0**（2026-05-15）：项目本地 18 件 mp-* skill 入库（mp-flow-* × 9 + mp-git-* × 6 + mp-doc-* × 3）；11 阶段速查表稳定
+- **v4.2.0**（2026-05-15）：Documentation Framework v1.0 入库；3 STANDARDs（Framework / Commit / GitHub Markdown）+ INDEX + 6 templates 落地
+- **v4.3.x – v4.4.11**（2026-05-15）：framework refinement / docs reorg / hook + CI consolidation / archive 机制 v4.4.0 引入 + v4.4.x flat layout
+- **v4.5.0**（2026-05-18）：Framework v1.4 → v1.5 取消 §1 豁免机制；HITL v1.3 → v1.4 §0 universal skeleton 内化；learn-kit v1.1.0 → v1.2.0 教学文档 6 → 2 [GUIDE] 合并；marketplace 独立性原则确立；8-layer commit-validation stack 完工
 
 ## AI Engineering
 
 marketplace AI agent 工作流规范（v4.1.0 起含 18 件项目本地 mp-* skill）：
 
-- **STANDARD（完整规范）**：[docs/rule/[STANDARD]_AI_Engineering_Execution_HITL_Prompt.md](docs/rule/[STANDARD]_AI_Engineering_Execution_HITL_Prompt.md) (v1.2)
+- **STANDARD（完整规范）**：[docs/rule/[STANDARD]_AI_Engineering_Execution_HITL_Prompt.md](docs/rule/[STANDARD]_AI_Engineering_Execution_HITL_Prompt.md) (v1.4)
 - **GUIDE（运行时勾选清单）**：[docs/guide/[GUIDE]_Marketplace_Agent_Execution_Checklist.md](docs/guide/[GUIDE]_Marketplace_Agent_Execution_Checklist.md)
 
 ### 11 阶段速查表

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # MJ AgentLab Marketplace
 
-![Version](https://img.shields.io/badge/version-4.4.8-blue)
+![Version](https://img.shields.io/badge/version-4.5.0-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 [![CI](https://github.com/MJ-AgentLab/mj-agentlab-marketplace/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/MJ-AgentLab/mj-agentlab-marketplace/actions/workflows/ci.yml)
 
 通用 [Claude Code](https://docs.anthropic.com/en/docs/claude-code) 插件市场——教学方法论 + NotebookLM 多媒体集成整合在单一 plugin。不绑定特定项目，可服务任意 Claude Code 使用者；在 [mj-system](https://github.com/MJ-AgentLab/mj-system) 与 mj-agent 两个项目上长期实战验证。
 
-> **v4.0.0 重大变更**：marketplace 从 "2 plugin（notebooklm-kit + learn-kit）" 收敛为 "1 plugin（learn-kit）"。原 `notebooklm-kit` 整个退场（7 个 skill 退役），其核心 build + studio 多媒体场景被 `learn-kit` 新增的 `nlm-studio` skill 吸收，并加入 **View-Purpose Preservation** 原则使生成的 artifact 严格匹配源 view（foundation/structural/challenge）的教学目的。详见 [docs/adr/[ADR]_NotebookLM_Kit_Retirement.md](docs/adr/[ADR]_NotebookLM_Kit_Retirement.md) + [docs/MIGRATION_GUIDE.md](docs/MIGRATION_GUIDE.md)。
+> **v4.0.0 重大变更**：marketplace 从 "2 plugin（notebooklm-kit + learn-kit）" 收敛为 "1 plugin（learn-kit）"。原 `notebooklm-kit` 整个退场（7 个 skill 退役），其核心 build + studio 多媒体场景被 `learn-kit` 新增的 `nlm-studio` skill 吸收，并加入 **View-Purpose Preservation** 原则使生成的 artifact 严格匹配源 view（foundation/structural/challenge）的教学目的。详见 [docs/adr/[ADR]_NotebookLM_Kit_Retirement.md](docs/adr/[ADR]_NotebookLM_Kit_Retirement.md) + [docs/guide/[GUIDE]_Migration_From_v3_to_v4.md](docs/guide/[GUIDE]_Migration_From_v3_to_v4.md)。
 
 ## 插件目录
 
 | Plugin | 描述 | Skills | Version | 适用项目 |
 |--------|------|--------|---------|---------|
-| [**learn-kit**](plugins/learn-kit/README.md) | 教学方法论 kit：把枚举型规则清单转化为人类可学习的决策框架解读文档（8 阶段方法 + 模板 + scaffold + locate / scan 项目内文档发现 + generate-tier AI 三档生成 + nlm-studio NotebookLM 多媒体生成） | **5** | **1.1.0** | 任意 |
+| [**learn-kit**](plugins/learn-kit/README.md) | 教学方法论 kit：把枚举型规则清单转化为人类可学习的决策框架解读文档（8 阶段方法 + 模板 + scaffold + locate / scan 项目内文档发现 + generate-tier AI 三档生成 + nlm-studio NotebookLM 多媒体生成） | **5** | **1.2.0** | 任意 |
 
 learn-kit 5 个 skill 用法：
 
@@ -98,7 +98,7 @@ nlm login
 - **`/notebooklm-kit:manage`（notebook 增删改 / 分享）** → 永久退役。直接用 notebooklm.google.com web UI
 - **`/notebooklm-kit:query`（跨 notebook 查询）** → 永久退役。同上
 
-完整迁移指引：[docs/MIGRATION_GUIDE.md](docs/MIGRATION_GUIDE.md)。
+完整迁移指引：[docs/guide/[GUIDE]_Migration_From_v3_to_v4.md](docs/guide/[GUIDE]_Migration_From_v3_to_v4.md)。
 
 ## 历史版本
 
@@ -112,14 +112,14 @@ nlm login
 ## 文档
 
 - 完整文档索引：[docs/INDEX.md](docs/INDEX.md)
-- 贡献指引与发布流程：[docs/CONTRIBUTING.md](docs/CONTRIBUTING.md)
+- 贡献指引与发布流程：[docs/guide/[GUIDE]_Contributing.md](docs/guide/[GUIDE]_Contributing.md)
 - 变更日志：[CHANGELOG.md](CHANGELOG.md)
-- 迁移指引：[docs/MIGRATION_GUIDE.md](docs/MIGRATION_GUIDE.md)
+- 迁移指引：[docs/guide/[GUIDE]_Migration_From_v3_to_v4.md](docs/guide/[GUIDE]_Migration_From_v3_to_v4.md)
 - ADR：[v4.0.0 notebooklm-kit 退场决策](docs/adr/[ADR]_NotebookLM_Kit_Retirement.md)
 
 ## 贡献
 
-欢迎贡献！本项目采用 **bare repo + worktree** 开发模型，详见 [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md)。
+欢迎贡献！本项目采用 **bare repo + worktree** 开发模型，详见 [docs/guide/[GUIDE]_Contributing.md](docs/guide/[GUIDE]_Contributing.md)。
 
 ## 许可证
 


### PR DESCRIPTION
## Bug 描述

main / develop 上的 `README.md` 在用户截图中显示 `version 4.4.8` badge + learn-kit 表格 `1.1.0`，但实际 marketplace 已发布 v4.5.0 + learn-kit 1.2.0。README 落后 **4 个 release** (v4.4.9 / v4.4.10 / v4.4.11 / v4.5.0)。同时 `CLAUDE.md` 也含大量 stale 内容（Documentation Framework 段、docs/ tree 段、历史版本记录段等），含 7 处 broken doc links (v4.5.0 PR #103 移动了 `docs/MIGRATION_GUIDE.md` + `docs/CONTRIBUTING.md`)。

## 根因分析

`scripts/bump-version.ps1` 第 58 行明确把 `README.md` 列入 `marketplace` scope TargetFiles，但**最近 4 次 release-bump commit 全部手工 edit 而未运行该 script**：

| commit | VERSION 改 | marketplace.json 改 | plugin.json 改 | README 改 |
|--------|------------|---------------------|----------------|-----------|
| v4.4.9 → v4.4.10 (e6a18cf) | ✓ | ✓ | ✓ | ✗ |
| v4.4.10 → v4.4.11 (e6a18cf) | ✓ | ✓ | ✓ | ✗ |
| v4.4.11 → v4.5.0 (2d299c9) | ✓ | ✓ | ✓ | ✗ |

CI 现有的 «Validate version consistency» step 仅校验 `VERSION ↔ marketplace.json ↔ plugin.json` 三角，**不检查 README badge**，所以 drift 在 CI 中完全无感。`CLAUDE.md` 同样是 manual-discipline 文件，无 script + 无 CI 守护。

## 修复方案

**A. 立即修复内容** (commit 1-2 + 5)
- commit 1 `docs(marketplace): refresh README badge 4.4.8 -> 4.5.0 + plugin + 5 links` — README.md 7 处编辑（badge + plugin 表 + 5 broken links）
- commit 2 `docs(marketplace): refresh CLAUDE.md to v4.5.0 + Framework v1.5 state` — CLAUDE.md 10 段更新（learn-kit version + Project Structure + Framework heading + docs/ tree + 历史版本记录 等）
- commit 5 `docs(marketplace): CHANGELOG [Unreleased] entries for readme-drift-fix` — 同步 4 entries

**B. 系统加固防再发** (commit 3-4)
- commit 3 `feat(ci): ci.yml validate README badge matches VERSION` — NEW CI step。`README.md` 第 3 行 badge 与 `VERSION` 不一致则 fail，error 提示 manual fix + `bump-version.ps1` 命令
- commit 4 `docs(marketplace): mp-doc-bump-version add README + CLAUDE to invariants` — Version Triangle (4-site) → Version Quintangle (5-site invariant)；Step 7 Verify 加 sed-based 检查（cross-platform：`grep -P` 在 Windows git-bash locale 下 fail；用 sed 通行）；anti-patterns 加 postmortem 注释

## 影响范围

- **不动**: VERSION / `.claude-plugin/marketplace.json` / `plugins/learn-kit/.claude-plugin/plugin.json` / `plugins/learn-kit/README.md` (agent audit 显示 plugin README 0 stale items)
- **改**: README.md / CLAUDE.md / `.github/workflows/ci.yml` / `.claude/skills/mp-doc-bump-version/SKILL.md` / `CHANGELOG.md`
- **不 bump**: 本 PR 是 documentation refresh + CI guard，无 plugin 行为变化，不触发 minor；让下次 coordinated release 一并 bump（precedent：PRs #105 + #106 也未 bump）

## 自检结果

- [x] **Bug 已复现并验证修复** — 本 PR commit 1 修完后，`grep -oP 'badge/version-\K[0-9]+\.[0-9]+\.[0-9]+' README.md` 输出 `4.5.0`，与 `cat VERSION` 一致
- [x] **无引入新的回归问题** — 仅文档 + CI step + skill 内容更新；无 plugin / runtime 改动
- [x] **无残留调试代码** — N/A（无代码 PR）
- [x] **Commit message 符合规范** — 5 commits 全部 PATTERN PASS（本地验证：`bash scripts/validate-commits.sh origin/develop..HEAD` → `[OK] 5 commit(s) validated; 0 failures`）
- [x] **CHANGELOG.md `[Unreleased]` 区块已更新** — commit 5 加 4 entries（Fixed × 2 + Added × 1 + Changed × 1）

## 本地验证

```text
$ bash scripts/validate-commits.sh origin/develop..HEAD
[OK] 5 commit(s) validated in range 'origin/develop..HEAD'; 0 failures
```

CI guard 自验证（Ubuntu sim）:
```text
FILE_VERSION=$(cat VERSION | tr -d '[:space:]')                                # 4.5.0
README_VERSION=$(grep -oP 'badge/version-\K[0-9]+\.[0-9]+\.[0-9]+' README.md)  # 4.5.0
[ "$FILE_VERSION" = "$README_VERSION" ] && echo OK                              # OK
```

## AI 自检

- [x] §3.1 #7 HITL trigger: ci.yml 修改（CI/CD 类）⚠️ — **已通过 plan 阶段获用户预批准** + 本 PR 内容显式列出 ci.yml 改动给 reviewer 确认
- [x] §3.1 #11 secret check: N/A — 仅文档 + CI step
- [x] §2.3.1 archive trigger: N/A — 无 STANDARD/RUNBOOK/ADR 改动（仅 SKILL.md 内容更新，frontmatter 字段结构不变）
- [x] §4.8 item 5 文档反向扫描: README + CLAUDE.md 中所有 `docs/MIGRATION_GUIDE.md` + `docs/CONTRIBUTING.md` 引用已全数 grep-replace 到新路径
- [x] §4.8 item 8 commit message format: 5/5 PASS

## Out of Scope (deferred to follow-up Issues)

本 PR 不做的（已开 GitHub Issues 跟进）:
- 扩展 `bump-version.ps1` 也 patch CLAUDE.md plugin line
- 重写 `[RUNBOOK]_Release_Operations.md` 强制 `bump-version.ps1` 使用
- CI step auto-fix mode (gh pr review 自动建议补丁)
- Audit 其他 stale docs（非 README + CLAUDE.md scope）

详见 #110 (bump-version.ps1 CLAUDE.md 扩展) + #111 (RUNBOOK 强制) + #112 (CI auto-fix) + #113 (docs audit)。

