### PR TITLE
docs(docs-runbook): Release_Operations v1.1 mandate bump-version.ps1 (closes #111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 ### Changed
 
 - **`.claude/skills/mp-doc-bump-version/SKILL.md`** — promote «Version Triangle (4-site)» → «Version Quintangle (5-site invariant)»: add README.md badge + plugin-table cell + CLAUDE.md plugin line. Frontmatter description extends version-bearing-files list. Step 7 Verify adds 3 new sed-based checks (cross-platform: `grep -P` is locale-sensitive on Windows git-bash) + cross-references ci.yml's new CI guard. Anti-patterns expand "4 sites" → "5 sites" + add explicit 4-release silent-drift postmortem note.
+- **`docs/runbook/[RUNBOOK]_Release_Operations.md` v1.0 → v1.1** (closes #111) — make `scripts/bump-version.ps1` invocation **MANDATORY** in the release workflow (not advisory). §3.2 rewritten as `[!IMPORTANT]` callout with PR #109 postmortem context + CI safety-net cross-ref. NEW §3.2.1 «Post-bump verification (MANDATORY)» with 3 checks: README in diff / CLAUDE.md grep / Quintangle 5-site sed alignment. §3.4 git add list explicitly includes `README.md` + `CLAUDE.md`; commit message example switched to canonical `infra(release): bump marketplace X.Y.Z -> Y.Z.W`; cross-ref `validate-commits.sh`. §6 发布前检查清单 加 3 NEW checkboxes + 发布后 加 1 visual badge verify. NEW §7 版本历史 + §8 (renumbered from §7) 相关文档. Fix line 350 `../CONTRIBUTING.md` → `../guide/[GUIDE]_Contributing.md` (was broken since PR #103 v4.5.0 rename). Frontmatter v1.0 → v1.1 + revision block. Non-trigger archive per Framework §2.3.1 (minor bump, no structural rewrite ≥50% / content replacement ≥70%).
+- **`docs/INDEX.md`** — Runbooks 表 `Release Operations` 行 last-verified `2026-05-14` → `2026-05-18` + description 加 v1.1 changelog 摘要.
 
 ## [4.5.0] - 2026-05-18
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -47,7 +47,7 @@ Navigation hub for all marketplace documentation.
 
 | Document | Description | Last verified |
 |----------|-------------|---------------|
-| [Release Operations](./runbook/[RUNBOOK]_Release_Operations.md) | 从开发到发布的完整操作流程（Issue → PR → Release）| 2026-05-14 |
+| [Release Operations](./runbook/[RUNBOOK]_Release_Operations.md) | 从开发到发布的完整操作流程（Issue → PR → Release）；v1.1 起 §3.2 bump-version.ps1 MANDATORY + §3.2.1 post-bump diff check | 2026-05-18 |
 | [Doc Archive Procedure](./runbook/[RUNBOOK]_Doc_Archive_Procedure.md) | 4-phase 文档归档工作流 + 2 HITL gate（per Documentation Framework v1.4 §2.3，flat layout）| 2026-05-17 |
 
 ## Architecture Decision Records (`docs/adr/`)

--- a/docs/runbook/[RUNBOOK]_Release_Operations.md
+++ b/docs/runbook/[RUNBOOK]_Release_Operations.md
@@ -1,13 +1,13 @@
 ---
 type: runbook
 scope: marketplace
-summary: 从功能开发到版本发布的完整操作流程 — Issue → PR → Release
+summary: 从功能开发到版本发布的完整操作流程 — Issue → PR → Release (v1.1 起：bump-version.ps1 MANDATORY + post-bump diff check)
 owner: marketplace-maintainers
 created: 2026-03-17
-updated: 2026-05-15
+updated: 2026-05-18
 state: active
-version: v1.0
-last-verified: 2026-05-14
+version: v1.1
+last-verified: 2026-05-18
 domain: release
 tags:
   - release
@@ -17,6 +17,9 @@ related:
   - ../guide/[GUIDE]_Version_Management.md
   - ../spec/[SPEC]_Marketplace_Json_Schema.md
   - ../rule/[STANDARD]_AI_Engineering_Execution_HITL_Prompt.md
+revision: |
+  2026-05-18 — v1.1: **bump-version.ps1 MANDATORY enforcement**（closes #111）。§3.2 重写为 MANDATORY callout（不再是 advisory）+ 新增 §3.2.1 post-bump verification step（`git diff --name-only` 必须含 `README.md` + Quintangle 5-site sed-based check）；§3.4 git add 列表新增 `README.md` + `CLAUDE.md` + commit message 改 release scope 范例；§6 发布前检查清单新增 3 项 NEW（script 已运行 / diff 含 README / CLAUDE.md plugin line 同步）+ 发布后新增 1 项（visual badge verify）；§7 新增 版本历史段（§8 即原 §7 相关文档）；fix line 350 `../CONTRIBUTING.md` → `../guide/[GUIDE]_Contributing.md` (PR #103 rename)；cross-reference v4.6.0 CI guard «Validate README badge matches VERSION»（PR #109）作为 safety net + Issue #110 / #113 future-work 锚点
+  2026-03-17 — v1.0: 初版
 ---
 
 # [RUNBOOK] 发布操作手册 — MJ AgentLab Marketplace
@@ -152,6 +155,14 @@ git push origin --delete feature/12-add-release-skill
 
 ### 3.2 Bump 版本号
 
+> [!IMPORTANT]
+> **MANDATORY**：必须运行 `scripts/bump-version.ps1`，禁止手工逐文件 edit。
+>
+> **为什么强制**：v4.4.9 → v4.5.0 期间 4 次 release-bump commit 连续手工 edit + 漏 `README.md`（badge 停在 4.4.8 横跨 4 个 release），直到用户截图发现。详见 [PR #109](https://github.com/MJ-AgentLab/mj-agentlab-marketplace/pull/109) postmortem。
+>
+> **Safety net**：CI 第「Validate README badge matches VERSION」步骤（PR #109 引入）会在 `README.md` badge 与 `VERSION` drift 时直接 fail。手工跳过 script 时 CI 会拒 PR。
+> CLAUDE.md plugin 行 + Quintangle 5-site 其余字段无 CI guard（追踪：[Issue #110](https://github.com/MJ-AgentLab/mj-agentlab-marketplace/issues/110) + [Issue #113](https://github.com/MJ-AgentLab/mj-agentlab-marketplace/issues/113)），故 script 是当前唯一可靠路径。
+
 在 develop worktree 中执行：
 
 ```bash
@@ -162,7 +173,7 @@ git pull origin develop
 **仅插件变更**：
 
 ```powershell
-# 预览
+# 预览（必跑：看清将改哪些文件）
 .\scripts\bump-version.ps1 -From "1.0.0" -To "1.1.0" -Scope "learn-kit" -DryRun
 
 # 执行
@@ -180,6 +191,27 @@ git pull origin develop
 ```
 
 **混合变更**：先 bump 各插件，再 bump marketplace。v4.0.0 / v4.3.0 即典型示例。
+
+#### 3.2.1 Post-bump verification (MANDATORY)
+
+执行 script 后立即跑（任一 ERROR 必须修正后才能进入 §3.3 CHANGELOG 转节）：
+
+```bash
+# 1. README.md 必须在 diff 中（marketplace scope 覆盖 badge + plugin table cell）
+git diff --name-only | grep -E "^README\.md$" || \
+  echo "ERROR: README.md not in diff — bump-version.ps1 was either skipped or failed silently"
+
+# 2. CLAUDE.md plugin line 验证（manual：script 不 cover；追踪 Issue #110）
+#    手工确认 CLAUDE.md `plugins/` 段 learn-kit 版本号已同步 plugin.json 的新版本
+grep -nE 'learn-kit. v[0-9.]+' CLAUDE.md
+
+# 3. Version Quintangle 5-site 一致性（详见 .claude/skills/mp-doc-bump-version/SKILL.md Step 7）
+v_root=$(cat VERSION)
+v_mp_meta=$(jq -r '.metadata.version' .claude-plugin/marketplace.json)
+v_readme_badge=$(sed -n 's/.*badge\/version-\([0-9.]\+\)-.*/\1/p' README.md | head -1)
+[ "$v_root" = "$v_mp_meta" ] && [ "$v_root" = "$v_readme_badge" ] && echo "OK: 5-site quintangle aligned" \
+  || echo "ERROR: site drift — re-run bump-version.ps1 with correct -From / -To"
+```
 
 ### 3.3 更新 CHANGELOG 正式版本节
 
@@ -212,13 +244,19 @@ git pull origin develop
 ### 3.4 提交发布变更
 
 ```bash
-git add VERSION .claude-plugin/marketplace.json CHANGELOG.md
+# Version Quintangle 5 sites + CHANGELOG（README 必须在列表中 — 由 §3.2.1 verification 保证已改）
+git add VERSION .claude-plugin/marketplace.json README.md CLAUDE.md CHANGELOG.md
+
 # 如有插件变更，也加上：
 git add plugins/learn-kit/.claude-plugin/plugin.json plugins/learn-kit/CHANGELOG.md
 
-git commit -m "infra(marketplace): release v1.1.0"
+# Commit 主语用 release scope（per `[STANDARD]_Commit_Message_Convention` §4）
+git commit -m "infra(release): bump marketplace 4.3.0 -> 4.3.1"
 git push origin develop
 ```
+
+> [!NOTE]
+> Commit message 必须符合 `[STANDARD]_Commit_Message_Convention` PATTERN — `infra(release): bump marketplace X.Y.Z -> Y.Z.W` 是合规范例。CI 第「Validate commit message format」步骤会拒非合规 commit；本地可先跑 `bash scripts/validate-commits.sh HEAD~1..HEAD` 自验证。
 
 ### 3.5 创建 Release PR
 
@@ -330,11 +368,15 @@ git push origin --delete v1.1.0
 
 - [ ] 所有目标变更已合并到 develop
 - [ ] CI 全部通过（Validate Structure: SUCCESS）
+- [ ] **(v1.1 NEW) `scripts/bump-version.ps1` 已运行**（先 DryRun + 看 diff preview，再执行；§3.2 MANDATORY）
+- [ ] **(v1.1 NEW) `git diff --name-only` 包含 `README.md`**（§3.2.1 verification — 若不在意味着 script 漏执行 / 失败）
+- [ ] **(v1.1 NEW) `CLAUDE.md` plugin line 已同步到新 plugin 版本**（script 当前不 cover，手工 grep verify；Issue #110 跟踪自动化）
 - [ ] CHANGELOG 已从 `[Unreleased]` 转为正式版本节
 - [ ] VERSION 文件已更新
 - [ ] marketplace.json 版本与 VERSION 一致
 - [ ] 各 plugin.json 版本与 marketplace.json 一致
 - [ ] 无未关闭的阻塞性 Issue
+- [ ] (本地预验证) `bash scripts/validate-commits.sh HEAD~N..HEAD` 全 PASS
 
 ### 发布后验证
 
@@ -342,9 +384,18 @@ git push origin --delete v1.1.0
 - [ ] Git tag 已生成（`git tag -l "vX.Y.Z"`）
 - [ ] Release notes 内容正确
 - [ ] `gh release view vX.Y.Z` 输出无异常
+- [ ] **(v1.1 NEW) 在 main 浏览 `README.md` 渲染 — badge 显示新版本号**（screenshot-level visual verify；post-PR #109 安全网）
 
-## 7. 相关文档
+## 7. 版本历史
+
+- **v1.1**（2026-05-18）：**bump-version.ps1 MANDATORY enforcement**（closes #111）。§3.2 改 advisory → MANDATORY callout box + 加 §3.2.1 post-bump verification（git diff README.md 必含 + Quintangle 5-site 一致性 sed-based check）；§3.4 git add 列表加 `README.md` + `CLAUDE.md` + 强调 release scope + 跨引用本地 `validate-commits.sh`；§6 发布前检查清单加 3 项 NEW + 发布后加 1 项 visual badge verify；§8 即原 §7 相关文档；fix line 350 `../CONTRIBUTING.md` → `../guide/[GUIDE]_Contributing.md` (PR #103 rename)；cross-reference v4.6.0 CI guard «Validate README badge matches VERSION»（PR #109）作为 safety net + Issue #110 / #113 future-work 锚点。Frontmatter v1.0 → v1.1 + revision block。Non-trigger archive（minor bump，无 Framework §2.3.1 触发条件）。
+- **v1.0**（2026-03-17）：初版。Issue → Branch → Develop → Commit → PR → CI → Merge → Release 完整 6 阶段操作流程 + hotfix + rollback 子流程。
+
+## 8. 相关文档
 
 - [项目概览](<../guide/[GUIDE]_Marketplace_Project_Overview.md>) — 项目整体概览
 - [版本管理指南](<../guide/[GUIDE]_Version_Management.md>) — 版本管理详细指南
-- [CONTRIBUTING.md](../CONTRIBUTING.md) — 贡献指南
+- [贡献指南](<../guide/[GUIDE]_Contributing.md>) — branch strategy + commit format + PR 流程
+- [Commit Message Convention](<../rule/[STANDARD]_Commit_Message_Convention.md>) — `<type>(<scope>): <summary>` PATTERN canonical
+- [mp-doc-bump-version SKILL.md](../../.claude/skills/mp-doc-bump-version/SKILL.md) — Version Quintangle 5-site invariant + Step 7 Verify
+- `.github/workflows/ci.yml` — 含「Validate README badge matches VERSION」step（PR #109 引入；safety net）


### PR DESCRIPTION
Closes #111.

## 文档变更内容

- **`docs/runbook/[RUNBOOK]_Release_Operations.md` v1.0 → v1.1** — make `scripts/bump-version.ps1` invocation MANDATORY:
  - **Frontmatter**: `version: v1.0 → v1.1`, `updated: 2026-05-15 → 2026-05-18`, `last-verified: 2026-05-14 → 2026-05-18`, add `revision: |` block
  - **§3.2**: rewrite advisory wording → `[!IMPORTANT]` MANDATORY callout box; embed PR #109 postmortem context + CI safety-net cross-ref
  - **§3.2.1 NEW**: «Post-bump verification (MANDATORY)» with 3 checks: README in diff / CLAUDE.md grep / Quintangle 5-site `sed` alignment (cross-platform: no `grep -P` so works on Windows git-bash)
  - **§3.4**: `git add` list explicitly includes `README.md` + `CLAUDE.md`; commit message example switched from `infra(marketplace): release v1.1.0` (non-canonical) to `infra(release): bump marketplace 4.3.0 -> 4.3.1` (matches PATTERN); cross-ref `validate-commits.sh` for local pre-validation
  - **§6 发布前检查清单**: add 3 NEW checkboxes (script ran / diff contains README / CLAUDE.md plugin line synced) + reorder existing items
  - **§6 发布后验证**: add 1 NEW item (visual badge verify — screenshot-level last-line safety post-PR #109)
  - **§7 NEW**: «版本历史» section with v1.0 + v1.1 entries
  - **§8 (renumbered from §7) 相关文档**: expand with 4 new cross-refs (Contributing renamed path + Commit Convention + mp-doc-bump-version SKILL + ci.yml CI guard)
  - **Bug fix**: line 350 `../CONTRIBUTING.md` → `../guide/[GUIDE]_Contributing.md` (was broken since PR #103 v4.5.0 rename)

- **`docs/INDEX.md`** — Runbooks table «Release Operations» row: `last-verified 2026-05-14 → 2026-05-18`; description appends v1.1 changelog summary

- **`CHANGELOG.md`** — `[Unreleased]` ### Changed adds 2 entries (RUNBOOK v1.1 + INDEX sync)

## 变更原因

Post-mortem of PR #109 (README + CLAUDE.md drift fix) identified `[RUNBOOK]_Release_Operations.md` as the **human-process root cause**: the runbook documented `scripts/bump-version.ps1` but didn't enforce its use. 4 successive release-bump commits (v4.4.9 / v4.4.10 / v4.4.11 / v4.5.0) skipped the script + edited files manually + missed `README.md`. The CI guard added in PR #109 («Validate README badge matches VERSION») is the technical safety net; this RUNBOOK update is the human-process safety net. Together they close the drift gap.

Issue #111 acceptance criteria (all met):
- [x] RUNBOOK explicitly marks `bump-version.ps1` as MANDATORY (not advisory) → §3.2 `[!IMPORTANT]` callout
- [x] Pre-commit verification step added (diff check) → NEW §3.2.1 with 3 checks
- [x] §6 release-prep checklist references README + CLAUDE.md → 3 NEW checkboxes
- [x] Cross-reference to CI guard added → §3.2 callout + §8 相关文档
- [x] Frontmatter `version:` bumped + revision block added → v1.0 → v1.1

## 自检结果

- [x] **文件命名符合 §2.4** — `[RUNBOOK]_Release_Operations.md` 路径稳定，无 `_vX.Y` 后缀（非 archived）
- [x] **frontmatter 含 8 必需字段** — type / scope / summary / owner / created / updated / state / version 全在 + revision block 加入
- [x] **文件位于正确子目录** — `docs/runbook/` (RUNBOOK 类)
- [x] **markdown 风格符合 [STANDARD]_GitHub_Markdown** — ATX headings (#### §3.2.1) / GFM tables / native `[!IMPORTANT]` + `[!NOTE]` alerts
- [x] **内部链接有效** — 修复 1 处 broken link（line 350 CONTRIBUTING.md 移到 guide/）；其余链接均验证存在
- [x] **`docs/INDEX.md` 已同步更新** — Release Operations 行 last-verified 更新 + description 加 v1.1 摘要
- [x] **CLAUDE.md 已同步更新** — 不涉及 Plugin 文档结构变更，无需同步（CLAUDE.md 已在 PR #109 更新到 v4.5.0 state）
- [x] **Commit message 符合 Convention** — 2 commits: `docs(docs-runbook): ...` + `docs(marketplace): ...`；均 PATTERN PASS（本地验证：`bash scripts/validate-commits.sh origin/develop..HEAD` → `[OK] 2 commit(s) validated; 0 failures`）

## Related STANDARDs

- [Documentation Framework](../../docs/rule/[STANDARD]_Documentation_Framework.md) v1.5 — Non-trigger archive check: minor bump（v1.0 → v1.1），无 §2.3.1 触发条件
- [Commit Message Convention](../../docs/rule/[STANDARD]_Commit_Message_Convention.md) v1.1 — 2 commits 均使用 `docs` 类型（documentation/* 分支 stylistic recommendation 合规）+ `docs-runbook` / `marketplace` scope 合规
- [HITL Prompt STANDARD](../../docs/rule/[STANDARD]_AI_Engineering_Execution_HITL_Prompt.md) v1.4 — §3.1 触发器检查全 ✅ pass（无 STANDARD 主版本 bump / ci.yml / secrets / main merge / archive trigger）
