### PR TITLE
feat(ci): readme-badge-suggest.yml Suggested Change bot (closes #112)

### DIFF
--- a/.github/workflows/readme-badge-suggest.yml
+++ b/.github/workflows/readme-badge-suggest.yml
@@ -1,0 +1,169 @@
+name: PR Suggest — README Badge Auto-Fix
+
+# Posts (or updates) a GitHub Suggested Change review comment on
+# README.md line 3 when the badge X.Y.Z drifts from VERSION. The user
+# can 1-click "Commit suggestion" to apply the fix.
+#
+# Closes Issue #112 (UX layer over the CI guard introduced in PR #109).
+# Defense-in-depth: ci.yml's "Validate README badge matches VERSION"
+# step BLOCKS merge on drift; this bot suggests the fix interactively.
+#
+# Why a separate workflow (not inline in ci.yml or in comment-on-pr.yml):
+# - ci.yml runs as 'pull_request' which has restricted GITHUB_TOKEN
+#   permissions on forks (no write access). workflow_run runs with
+#   the BASE repo's token, allowing PR review-comment writes safely.
+# - comment-on-pr.yml is scoped to commit-message validation; mixing
+#   README badge logic would muddle single-responsibility.
+# - Distinct comment APIs: this uses `pulls/{n}/comments` (review
+#   comments anchored to file+line, required for Suggested Change
+#   syntax to render the "Commit suggestion" button) vs comment-on-pr.yml
+#   uses `issues/{n}/comments` (general PR comment).
+#
+# Sticky semantics: one review comment per PR, edited in place via
+# marker `<!-- readme-badge-suggest-bot -->`. When drift is resolved
+# (e.g., user clicked "Commit suggestion" or pushed a fix manually),
+# the bot DELETES the marker comment so the PR doesn't show a "ghost"
+# Suggested Change.
+#
+# Test note: workflow_run-triggered workflows run from the DEFAULT
+# branch's workflow definition, so this file's first opportunity to
+# fire is AFTER it merges to develop. Initial validation will be done
+# by intentionally introducing drift in a follow-up test PR.
+
+on:
+  workflow_run:
+    workflows: ["CI — Validate Plugin Structure"]
+    types: [completed]
+
+permissions:
+  pull-requests: write   # POST/PATCH/DELETE review comments
+  actions: read          # download nothing here; reserved for future artifact use
+  contents: read         # checkout PR's commit to read VERSION + README.md
+
+jobs:
+  suggest:
+    name: Post README badge Suggested Change
+    runs-on: ubuntu-latest
+    # Only run on PR events; skip push runs (release branches, main, develop)
+    if: >-
+      github.event.workflow_run.event == 'pull_request'
+      && github.event.workflow_run.pull_requests[0] != null
+    steps:
+      - name: Checkout PR head commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 1
+
+      - name: Detect README badge drift
+        id: drift
+        run: |
+          FILE_VERSION=$(cat VERSION | tr -d '[:space:]')
+          README_VERSION=$(grep -oP 'badge/version-\K[0-9]+\.[0-9]+\.[0-9]+' README.md | head -1)
+
+          if [ -z "$README_VERSION" ]; then
+            # No badge line at all — let the ci.yml step handle this (it'll fail there too)
+            echo "drift=missing-badge" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "$FILE_VERSION" = "$README_VERSION" ]; then
+            echo "drift=none" >> "$GITHUB_OUTPUT"
+            echo "OK: README badge matches VERSION ($FILE_VERSION) — no suggestion needed"
+          else
+            echo "drift=yes" >> "$GITHUB_OUTPUT"
+            echo "file_version=$FILE_VERSION" >> "$GITHUB_OUTPUT"
+            echo "readme_version=$README_VERSION" >> "$GITHUB_OUTPUT"
+            # Find badge line number for review comment placement
+            BADGE_LINE=$(grep -n 'badge/version-' README.md | head -1 | cut -d: -f1)
+            echo "badge_line=$BADGE_LINE" >> "$GITHUB_OUTPUT"
+            echo "DRIFT: README badge ($README_VERSION) != VERSION ($FILE_VERSION) at line $BADGE_LINE"
+          fi
+
+      - name: Find existing marker comment (if any)
+        id: existing
+        if: steps.drift.outputs.drift != 'missing-badge'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+        run: |
+          MARKER='<!-- readme-badge-suggest-bot -->'
+
+          EXISTING_ID=$(gh api "repos/$GH_REPO/pulls/$PR_NUMBER/comments" --paginate \
+            --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" \
+            | head -n 1)
+
+          if [ -n "$EXISTING_ID" ]; then
+            echo "existing_id=$EXISTING_ID" >> "$GITHUB_OUTPUT"
+            echo "Found existing review comment id=$EXISTING_ID"
+          else
+            echo "existing_id=" >> "$GITHUB_OUTPUT"
+            echo "No existing review comment found"
+          fi
+
+      - name: Resolve drift — delete stale suggestion (drift now fixed)
+        if: steps.drift.outputs.drift == 'none' && steps.existing.outputs.existing_id != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          EXISTING_ID: ${{ steps.existing.outputs.existing_id }}
+        run: |
+          echo "Drift resolved — deleting stale Suggested Change comment id=$EXISTING_ID"
+          gh api -X DELETE "repos/$GH_REPO/pulls/comments/$EXISTING_ID"
+
+      - name: Post or update Suggested Change review comment
+        if: steps.drift.outputs.drift == 'yes'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          CI_URL: ${{ github.event.workflow_run.html_url }}
+          FILE_VER: ${{ steps.drift.outputs.file_version }}
+          README_VER: ${{ steps.drift.outputs.readme_version }}
+          BADGE_LINE: ${{ steps.drift.outputs.badge_line }}
+          EXISTING_ID: ${{ steps.existing.outputs.existing_id }}
+        run: |
+          MARKER='<!-- readme-badge-suggest-bot -->'
+
+          BODY_FILE="$RUNNER_TEMP/suggestion-body.md"
+          cat > "$BODY_FILE" <<EOF
+          $MARKER
+          ## ⚠️ README Badge Drift Detected
+
+          \`VERSION\` says **$FILE_VER** but \`README.md\` line $BADGE_LINE badge says **$README_VER**.
+
+          **Apply the fix in 1 click** (GitHub renders a "Commit suggestion" button below):
+
+          \`\`\`suggestion
+          ![Version](https://img.shields.io/badge/version-${FILE_VER}-blue)
+          \`\`\`
+
+          Or locally, to bump all 5 Quintangle sites at once:
+          \`\`\`powershell
+          pwsh ./scripts/bump-version.ps1 -From ${README_VER} -To ${FILE_VER}
+          \`\`\`
+
+          See [\`[RUNBOOK]_Release_Operations\`](../blob/$HEAD_SHA/docs/runbook/%5BRUNBOOK%5D_Release_Operations.md) §3.2 (MANDATORY) for the canonical release-bump procedure.
+
+          _Posted by \`readme-badge-suggest.yml\` after [CI run]($CI_URL). Auto-updates / auto-resolves on each push._
+          EOF
+
+          # Strategy: DELETE old + POST new (preferred over PATCH because PATCH
+          # can't change commit_id, leaving suggestion anchored to a stale commit).
+          if [ -n "$EXISTING_ID" ]; then
+            echo "Deleting stale review comment id=$EXISTING_ID before posting fresh"
+            gh api -X DELETE "repos/$GH_REPO/pulls/comments/$EXISTING_ID" || true
+          fi
+
+          echo "Posting review comment on README.md line $BADGE_LINE at commit $HEAD_SHA"
+          gh api -X POST "repos/$GH_REPO/pulls/$PR_NUMBER/comments" \
+            -f body="$(cat "$BODY_FILE")" \
+            -f commit_id="$HEAD_SHA" \
+            -f path="README.md" \
+            -F line="$BADGE_LINE" \
+            -f side="RIGHT" \
+            >/dev/null
+
+          echo "Suggested Change posted. User can click 'Commit suggestion' to apply."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Added
 
 - **`.github/workflows/ci.yml`** — NEW step «Validate README badge matches VERSION» appended after «Validate version consistency». Guards against the silent badge drift that produced the v4.4.8-stuck-while-on-v4.5.0 postmortem. Fails CI if `README.md` line 3 badge encodes a different `X.Y.Z` than the `VERSION` file. Error output suggests both manual-edit fix + `bump-version.ps1` command. Runs on all PRs + branch pushes (no `release/*` skip).
+- **`.github/workflows/readme-badge-suggest.yml`** (PR #117 closes #112) — NEW PR Suggested Change bot. Triggers on `workflow_run` after `CI — Validate Plugin Structure` completes; checks README badge vs VERSION; if drift exists, posts a GitHub review comment on README.md badge line with a ` ```suggestion ` block. User clicks "Commit suggestion" to apply the fix in 1 click (no local edit needed). Sticky semantics via marker `<!-- readme-badge-suggest-bot -->` — DELETE+POST on each push so the suggestion always anchors to the current commit_id. Auto-resolves the marker comment when drift is fixed (avoids ghost suggestions). Uses `pulls/{n}/comments` API (review comments anchored to file+line — required for Suggested Change syntax) vs `comment-on-pr.yml` which uses `issues/{n}/comments` (general PR comment) — distinct concerns, separate workflows for SRP. Defense-in-depth UX layer over PR #109's blocking CI guard.
 
 ### Changed
 


### PR DESCRIPTION
Closes #112.

## 变更摘要

NEW workflow `.github/workflows/readme-badge-suggest.yml` — **GitHub Suggested Change bot** that auto-suggests the README badge fix when it drifts from `VERSION`. Defense-in-depth UX layer over PR #109's CI guard (which blocks merge on drift but only emits a text error). With this bot, the contributor sees a "Commit suggestion" button and applies the fix in 1 click.

**Single commit**: `feat(ci): add readme-badge-suggest.yml Suggested Change bot`

## 影响范围

**New file** (1):
- `.github/workflows/readme-badge-suggest.yml` — 170 lines of YAML + heredoc bash

**Modified** (1):
- `CHANGELOG.md` `[Unreleased]` ### Added — entry for the new workflow

**Not modified**: no existing workflow touched; no schema/secrets/version files; no skill / doc / plugin changes.

## 审核要点

⚠️ **HITL §3.1 #8 trigger** — `.github/workflows/*` change (CI/CD category). Disclosure:
- **Pure addition**: zero modification to existing workflows (ci.yml / release.yml / comment-on-pr.yml untouched)
- **Permission model**: `pull-requests: write` + `actions: read` + `contents: read` — same scope as already-granted comment-on-pr.yml
- **Token source**: workflow_run uses BASE-repo GITHUB_TOKEN, safe for fork PRs (same pattern as comment-on-pr.yml)
- **Drift logic mirrors** the already-vetted ci.yml «Validate README badge matches VERSION» step (same grep `-oP 'badge/version-\K[0-9]+\.[0-9]+\.[0-9]+'` pattern)
- **No third-party actions**: uses only `actions/checkout@v4` (already in ci.yml) + `gh` CLI (built into runner)

**Review focus**:
1. Workflow file header comment block documents 5 design decisions — please verify the SRP / sticky strategy / DELETE+POST rationale aligns with project conventions
2. The Suggested Change body uses GFM `` ```suggestion `` block (GitHub's special syntax that renders the "Commit suggestion" button)
3. Auto-resolve logic (delete marker comment when drift fixed) prevents "ghost" suggestions on resolved PRs

## 自检结果

- [x] **plugin.json 字段完整** — N/A, no plugin changes
- [x] **SKILL.md frontmatter 有效** — N/A, no skill changes
- [x] **文档合规** — N/A, no `docs/**/*.md` changes (CHANGELOG.md updates are routine)
- [x] **无硬编码** — All values are GitHub Actions context variables or computed from VERSION/README.md at runtime
- [x] **无残留调试代码** — N/A
- [x] **Commit message 符合 Convention** — 1 commit, PATTERN PASS (`bash scripts/validate-commits.sh HEAD~1..HEAD` → `[OK] 1 commit(s) validated; 0 failures`); `feat(ci):` scope correct (CI workflow addition)
- [x] **CHANGELOG.md `[Unreleased]` 区块已更新** — NEW ### Added entry describing the workflow + sticky semantics + 5 design decisions summary

## 本地验证

**YAML syntax**: file written via Write tool (no syntax errors at write-time; full validation deferred to GitHub Actions parser).

**Logic correctness**: drift detection re-uses the same grep regex as `ci.yml` (`badge/version-\K[0-9]+\.[0-9]+\.[0-9]+`). When ci.yml passes for README → this bot's drift check returns `none` → no suggestion. When ci.yml fails for README → this bot's drift check returns `yes` → suggestion posted.

**Sticky behavior verified by design**:
- First push with drift → POST new review comment
- Subsequent push with drift (different commit_id) → DELETE old + POST new (suggestion now anchored to current commit)
- Push that fixes drift → DELETE old marker comment (PR no longer shows ghost suggestion)
- Push with no prior drift → no-op

## 已知限制 (Acknowledged)

**workflow_run-triggered workflows can't be tested in their own introducing PR.** GitHub Actions runs the workflow definition from the **default branch** at trigger time, not the PR branch. So `readme-badge-suggest.yml` won't fire on this PR. First firing opportunity is AFTER merge to develop.

**Validation plan** (post-merge):
1. Create a test PR that bumps VERSION to a new patch (e.g., 4.5.0 → 4.5.0-test) WITHOUT updating README badge
2. Wait for ci.yml to fail at the «Validate README badge matches VERSION» step
3. Wait for `readme-badge-suggest.yml` to fire (workflow_run after ci.yml completion)
4. Verify a review comment appears on README.md badge line with the ` ```suggestion ` block
5. Click "Commit suggestion" → README.md badge updates → push triggers re-run → CI passes → bot deletes the marker comment

This is a standard GitHub Actions limitation, not a flaw in the workflow design.

## AI 自检

- [x] §3.1 HITL trigger 检查: ⚠️ #8 ci.yml/release.yml/workflows change — disclosed above for user review
- [x] §3.1 #11 secrets check: GITHUB_TOKEN is GitHub-provided, scoped to `pull-requests: write` + `actions: read` + `contents: read` only; no custom secrets
- [x] §4.8 item 5a 反向扫描: no doc paths renamed in this PR; CHANGELOG-only doc touch
- [x] §4.8 item 8 commit message: PASS
- [x] No VERSION bump (additive feature, no semver impact for marketplace users)

## Related STANDARDs

- [HITL Prompt STANDARD](../../docs/rule/[STANDARD]_AI_Engineering_Execution_HITL_Prompt.md) v1.4 — §3.1 #8 CI/CD HITL trigger DISCLOSED + reviewed
- [Commit Message Convention](../../docs/rule/[STANDARD]_Commit_Message_Convention.md) v1.1 — PATTERN PASS

## Related

- Closes Issue #112
- Completes the post-v4.5.0 drift-defense quartet:
  - **PR #109**: Root README + CLAUDE.md drift fix + ci.yml CI guard (drift BLOCKS merge)
  - **PR #114**: `[RUNBOOK]_Release_Operations` v1.1 mandates `bump-version.ps1` (human-process gate)
  - **PR #115**: `bump-version.ps1` covers all 5 Quintangle sites incl. CLAUDE.md (automation gate)
  - **PR #117** (this): Suggested Change bot for 1-click fix (UX gate)
- Builds on PR #116's audit cleanup; develops the same "comment-on-pr.yml" pattern for a different concern
