### PR TITLE
docs: scrub mj-system refs from PR #120 governance docs (per STANDARD §0.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,18 @@
 
 ### Added
 
-- **Develop post-release pre-bump 机制**（借鉴 [mj-system](https://github.com/MJ-AgentLab/mj-system)）— 每次 release + sync-main-to-develop 完成后，在 develop 上额外 `bump-version.ps1 -From X.Y.Z -To X.Y.(Z+1)` 一个 commit，保证 `develop VERSION > main VERSION` 恒成立。Pure patch 风格无 `-dev` 后缀；只 bump 顶层 VERSION，不连带 plugin.json。详见 [docs/adr/[ADR]_Develop_PreBump_Adoption.md](docs/adr/[ADR]_Develop_PreBump_Adoption.md)。
-- **`docs/adr/[ADR]_Develop_PreBump_Adoption.md`** — 决策文档：从 mj-system 借鉴 3 项机制（pre-bump + CHANGELOG PR-time 纪律 + warn-only CI 检查）；不借鉴 `plans/[PLAN]_Release_*.md` 第 4 项（违反 `[STANDARD]_AI_Engineering_Execution_HITL_Prompt` §4.3；marketplace `CHANGELOG.md` 已承担同等审计职能）。
+- **Develop post-release pre-bump 机制** — 每次 release + sync-main-to-develop 完成后，在 develop 上额外 `bump-version.ps1 -From X.Y.Z -To X.Y.(Z+1)` 一个 commit，让 `develop VERSION > main VERSION` 成为 marketplace 内部硬不变式 —— 肉眼可见 develop 是否领先 main，回答 release readiness 不再需要 git log / CHANGELOG 二次确认。Pure patch 风格无 `-dev` 后缀；只 bump 顶层 VERSION，不连带 plugin.json。详见 [docs/adr/[ADR]_Develop_PreBump_Adoption.md](docs/adr/[ADR]_Develop_PreBump_Adoption.md)。
+- **`docs/adr/[ADR]_Develop_PreBump_Adoption.md`** — 决策文档：3 项机制（pre-bump + CHANGELOG PR-time 纪律 + warn-only CI 检查）；不采用 `plans/[PLAN]_Release_*.md` audit doc 模式（违反 `[STANDARD]_AI_Engineering_Execution_HITL_Prompt` §4.3；marketplace `CHANGELOG.md` 已承担同等审计职能）。后续 v1.1 scrub 外部项目引用 per STANDARD §0.3。
 - **`.github/workflows/verify-develop-prebumped.yml`** — warn-only CI 工作流：develop push 时检查 `develop VERSION > main VERSION` 是否成立；若等于且距 main 最后 commit 已 ≥ 72h，输出 workflow summary 警告（永不 `exit 1`）。
 - **PR 模板 CHANGELOG checkbox 全覆盖** — `documentation.md` / `maintain.md` / `hotfix.md` / `PULL_REQUEST_TEMPLATE.md` (fallback) 4 个模板补齐 `[Unreleased]` checkbox，与 `feature.md` / `bugfix.md` 现有项目对齐，5 类 PR 全覆盖。
-- **首次预 bump执行**：本次 PR 含 `infra(release): pre-bump develop 4.6.0 -> 4.6.1 (post-v4.6.0)` commit 作为新机制启动点；下次 release 即从 4.6.1 切版本（除非有 minor/major 升级需求）。
+- **首次预 bump 执行**：PR #120 含 `infra(release): pre-bump develop 4.6.0 -> 4.6.1 (post-v4.6.0)` commit 作为新机制启动点；下次 release 即从 4.6.1 切版本（除非有 minor/major 升级需求）。
 
 ### Changed
 
-- **`docs/runbook/[RUNBOOK]_Release_Operations.md`** v1.2 → v1.3：新增 §3.7 "Post-release develop 预 bump"；§4.5 加 hotfix 与预 bump 冲突 TODO 标记（待首次 hotfix 事件发生时补 §4.6）；§6 发布后检查清单加 1 项 "72h 内完成预 bump"。
+- **`docs/runbook/[RUNBOOK]_Release_Operations.md`** v1.2 → v1.3 → v1.3.1：v1.3 新增 §3.7 "Post-release develop 预 bump" + §4.5 hotfix 与预 bump 冲突 TODO 标记 + §6 发布后检查清单加 1 项 "72h 内完成预 bump"；v1.3.1 scrub frontmatter summary + revision + §3.7 callout 中的外部项目引用 per STANDARD §0.3。
 - **`README.md`** — 加 develop badge 语义脚注（"develop branch badge = 预计下一个 release 号"）。
 - **`CLAUDE.md`** — Key Conventions 段加 2 项：post-release pre-bump 机制 + develop README badge 语义说明；引用新 ADR + RUNBOOK §3.7。
+- **`docs/adr/[ADR]_Develop_PreBump_Adoption.md`** v1.0 → v1.1（follow-up scrub PR）：reframe §1 Context / §2 Decision / §3 Consequences / §4 Alternatives / §7 References，去除外部项目引用 per STANDARD §0.3；技术决策不变。
 
 ## [4.6.0] - 2026-05-18
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -6,7 +6,7 @@ owner: marketplace-maintainers
 created: 2026-05-15
 updated: 2026-05-18
 state: active
-version: v4.6
+version: v4.6.1
 domain: governance
 tags:
   - index
@@ -14,6 +14,7 @@ tags:
 related:
   - ./rule/[STANDARD]_Documentation_Framework.md
 revision: |
+  2026-05-18 — v4.6.1: scrub external project reference from [ADR]_Develop_PreBump_Adoption row description per `[STANDARD]_AI_Engineering_Execution_HITL_Prompt` §0.3
   2026-05-18 — v4.6: add [ADR]_Develop_PreBump_Adoption row + update RUNBOOK_Release_Operations row to mention v1.3 §3.7 pre-bump
   2026-05-18 — v4.5: add 8-field frontmatter (Framework v1.5 §1 INDEX special clause); update Framework v1.4→v1.5 + HITL v1.3→v1.4 + learn-kit 1.1.0→1.2.0 entries; remove deleted ai_engineering_execution_hitl_workflow.md row; move Exemption Review ADR to Archived section; add Exemption Reversal ADR; update CONTRIBUTING + MIGRATION_GUIDE paths to docs/guide/; update plugin-internal teaching series description to reflect 6→2 consolidation
 ---
@@ -57,7 +58,7 @@ Navigation hub for all marketplace documentation.
 |----------|-------------|
 | [ADR: NotebookLM Kit Retirement](./adr/[ADR]_NotebookLM_Kit_Retirement.md) | v4.0.0 删除 notebooklm-kit + 把核心 build / studio 多媒体场景吸收到 learn-kit 的决策 |
 | [ADR: Documentation Framework Exemption Reversal](./adr/[ADR]_Documentation_Framework_Exemption_Reversal.md) | v4.5.0 取消 Framework v1.1 §1 单文件 + 教学系列模式豁免；supersedes 旧 Exemption Review ADR（archived）|
-| [ADR: Develop Pre-Bump Adoption](./adr/[ADR]_Develop_PreBump_Adoption.md) | v4.6.1 起借鉴 mj-system：每次 release + sync-main-to-develop 完成后，在 develop 上预 bump 到下一个 patch；保证 `develop VERSION > main VERSION` 恒成立 |
+| [ADR: Develop Pre-Bump Adoption](./adr/[ADR]_Develop_PreBump_Adoption.md) | v4.6.1 起每次 release + sync-main-to-develop 完成后，在 develop 上预 bump 到下一个 patch；保证 `develop VERSION > main VERSION` 恒成立，让 release readiness 信号肉眼可见 |
 
 > Plugin-internal ADRs（如 `[ADR]_LearnKit_Discovery_Skills`，v4.3.0 起迁入 `plugins/learn-kit/docs/adr/`）见各 plugin 的 docs/INDEX.md。
 

--- a/docs/adr/[ADR]_Develop_PreBump_Adoption.md
+++ b/docs/adr/[ADR]_Develop_PreBump_Adoption.md
@@ -1,17 +1,20 @@
 ---
 type: adr
 scope: marketplace
-summary: 借鉴 mj-system 在 develop 分支引入 post-release 预 bump 机制
+summary: 在 develop 分支引入 post-release 预 bump 机制，使 develop VERSION 始终领先 main
 owner: ranzuozhou
 created: 2026-05-18
 updated: 2026-05-18
 state: active
-version: v1.0
+version: v1.1
 domain: release
 related:
   - ../runbook/[RUNBOOK]_Release_Operations.md
   - ../rule/[STANDARD]_AI_Engineering_Execution_HITL_Prompt.md
   - ../rule/[STANDARD]_Documentation_Framework.md
+revision: |
+  2026-05-18 — v1.1: scrub external project references per `[STANDARD]_AI_Engineering_Execution_HITL_Prompt` §0.3 independence principle; reframe §1 Context / §2 Decision / §3 Consequences / §4 Alternatives with marketplace-internal rationale; remove §7 external reference repo line; technical decision unchanged.
+  2026-05-18 — v1.0: 初版（含外部项目引用，v1.1 已 scrub）
 ---
 
 # [ADR] develop 分支 Post-Release 预 bump 机制
@@ -26,47 +29,48 @@ related:
 
 ## §1 Context
 
-v4.6.0 发布完成后，`develop` 与 `main` 的 `VERSION` 文件均停在 `4.6.0`，与 `[RUNBOOK]_Release_Operations` v1.2 "release-time bump" 策略的预期完全一致。但维护者对此产生疑问："发布版本 = develop 版本" 是否合理？
+v4.6.0 发布完成后，`develop` 与 `main` 的 `VERSION` 文件均停在 `4.6.0`，与 `[RUNBOOK]_Release_Operations` v1.2 "release-time bump" 策略的预期完全一致。该状态本身**不是 bug**，但触发了一个 release readiness signal 模糊性问题：
 
-调查发现：
+- 在 develop 上肉眼看 `VERSION=4.6.0`，无法直接判断 "develop 是否有未发布变更累积"。要回答这个问题，必须 `git log origin/main..develop` 或扫 `CHANGELOG.md [Unreleased]` 段。
+- 这种 ambiguity 在多 PR 累积窗口尤其明显：维护者切上 develop 后需额外认知步骤判断当前状态。
+- CI 端只有 `Validate README badge matches VERSION` 一道 invariant，没有 "develop 是否已经准备好发布" 这种 hygiene 维度的反馈。
 
-- 这本身**不是 bug** —— marketplace 当前 release-time bump 策略 + `[GUIDE]_Version_Management` v1.0 + sync-main-to-develop PR (PR #119) 三者协同的预期产物。
-- 但参考姊妹项目 [mj-system](https://github.com/MJ-AgentLab/mj-system) 发现它采用 **post-release pre-bump** 模式：v3.2.1 发布后 develop 立即 bump 到 3.2.2（pure patch，无 `-dev` 后缀），让 `develop VERSION > main VERSION` 始终成立。
-- 维护者核心诉求是 **与 mj-system 的版本管理心智模型对齐**，避免维护两套工作流。
+约束：
 
-约束：marketplace 必须遵守 `[STANDARD]_AI_Engineering_Execution_HITL_Prompt` §0.4 / §4.3 的明确约束 "marketplace **不维护** `plans/` 目录"，所以不能照搬 mj-system 的 `plans/[PLAN]_Release_vX.Y.Z.md` 审计文档习惯。
+- marketplace 必须遵守 `[STANDARD]_AI_Engineering_Execution_HITL_Prompt` §0.4 / §4.3 "marketplace **不维护** `plans/` 目录" 的约束。
+- 现有 5 类 PR 模板中只有 `feature.md` / `bugfix.md` 含 `CHANGELOG [Unreleased]` checkbox；`documentation.md` / `maintain.md` / `hotfix.md` / fallback 模板未覆盖，纪律不齐。
+- marketplace dual-layer versioning（顶层 `VERSION` + per-plugin `plugin.json`）要求任何机制都要明确作用于哪一层。
 
 ## §2 Decision
 
-We decide to **借鉴 mj-system 4 项发布相关机制中的 3 项到 marketplace**：
+We decide to **在 develop 分支引入 post-release 预 bump 机制**，并配套 2 项流程纪律：
 
-- **采用** develop 分支 post-release 预 bump（pure patch 风格：4.6.0 → 4.6.1）。每次 release sync-main-to-develop 完成后，在 develop 加 1 个 `infra(release): pre-bump develop X.Y.Z -> X.Y.(Z+1) (post-vX.Y.Z)` commit。
-- **采用** CHANGELOG `[Unreleased]` PR-time 纪律：feature/bugfix/documentation/maintain/hotfix 5 类 PR 模板均含 CHANGELOG checkbox（feature/bugfix 已有；本 ADR 补齐 documentation/maintain/hotfix）。
-- **采用** warn-only CI 预 bump 状态检查（`verify-develop-prebumped.yml`），post-release 72h 宽限窗口之外报 workflow summary 警告，永不 `exit 1`。
-- **不采用** mj-system 的 `plans/[PLAN]_Release_vX.Y.Z.md` 审计文档机制 —— marketplace `CHANGELOG.md` 现已承担同等审计职能（v4.6.0 entry 含 per-PR breakdown + 4-layer defense table + root cause + lessons），且 STANDARD §4.3 明确禁止 marketplace 维护 `plans/` 目录。
+- **核心机制：develop pre-bump**（pure patch 风格，4.6.0 → 4.6.1）。每次 release PR 合并 main + sync-main-to-develop PR 合并 develop 之后，在 develop 上加 1 个 `infra(release): pre-bump develop X.Y.Z -> X.Y.(Z+1) (post-vX.Y.Z)` commit。**只 bump 顶层 `VERSION` + `marketplace.json metadata.version` + `README.md` badge** 三处；plugin.json 不动（plugin 按自身节奏 bump，预 bump plugin 会产生 "plugin 有未发变更" 假信号）。
+- **CHANGELOG `[Unreleased]` PR-time 纪律**：5 类 PR 模板均含 CHANGELOG checkbox（feature/bugfix 已有；本 ADR 补齐 documentation/maintain/hotfix/fallback），让 [Unreleased] 段在每次 PR 时即累积变更。
+- **Warn-only CI 状态检查**（`verify-develop-prebumped.yml`）：post-release 72h 宽限窗口之外报 workflow summary 警告，永不 `exit 1`。
 
 Boundary:
 
-- **In-scope**: marketplace 顶层 `VERSION` + `marketplace.json metadata.version` + `README.md` badge 的预 bump。
+- **In-scope**: marketplace 顶层 `VERSION` + `marketplace.json metadata.version` + `README.md` badge 的预 bump；5 类 PR 模板 CHANGELOG checkbox 覆盖；develop push 时的 warn-only CI 检查。
 - **Out-of-scope**:
-  - Plugin 级 `plugin.json` 预 bump（marketplace 双层 versioning；plugin 应按自身节奏 bump，预 bump 会产生 "plugin 有未发变更" 假信号）。
-  - Hotfix 与预 bump 的冲突处理（暂无 hotfix 高频场景；RUNBOOK 加 TODO 标记，待首次事件再补 §3.9）。
+  - Plugin 级 `plugin.json` 预 bump（dual-layer versioning 隔离原则）。
+  - Hotfix 与预 bump 的冲突处理（暂无 hotfix 高频场景；RUNBOOK §4.5 加 TODO 标记，待首次事件再补 §4.6）。
+  - CHANGELOG [Unreleased] 的 CI 守门（暂依赖 PR review 纪律；6 个月内若漏更新频次高再追加 warn-only CI）。
 - **Open questions**:
   - 72h 宽限窗口是否合适？暂按经验值；若观察到 false-positive 频次高再调。
-  - CHANGELOG `[Unreleased]` CI 守门是否需要？暂不加，靠 PR review 纪律；6 个月内若漏更新频次高再追加 warn-only CI。
 
 ## §3 Consequences
 
 ### §3.1 Positive
 
-- `develop VERSION > main VERSION` 成为肉眼可见的 "develop 是否领先 main" 信号，与 mj-system 心智模型一致。
-- 跨 marketplace ↔ mj-system 维护者无需切换工作流，减少认知负担。
-- CI `verify-develop-prebumped.yml` warn-only 在 release 后 72h 未预 bump 时主动提醒，闭合 "忘记预 bump" 风险。
-- CHANGELOG PR 纪律覆盖 5 类 PR 模板，让 [Unreleased] 段在每次 PR 时即累积，避免 release-time 集中回忆累积变更。
+- `develop VERSION > main VERSION` 成为 marketplace 内部的硬不变式：肉眼可见 "develop 是否领先 main"，回答 release readiness 不再需要 git log / CHANGELOG 二次确认。
+- Warn-only CI 在 release 后 72h 未预 bump 时主动提醒，闭合 "忘记预 bump" 这类 hygiene 风险。
+- CHANGELOG PR 纪律覆盖 5 类 PR 模板，让 [Unreleased] 段在每次 PR 时即累积，避免 release-time 集中回忆累积变更（v4.5.0 → v4.6.0 期间 [Unreleased] 段在 release-cut 时为空就是该问题的实例）。
+- 与既有 4-layer drift defense（PR #109 + #114 + #115 + #117）形成互补：drift defense 防止 VERSION 漂移，pre-bump invariant 防止 VERSION 停滞。
 
 ### §3.2 Negative
 
-- Develop 的 `README.md` badge 在预 bump 后显示 "4.6.1"，但 `v4.6.1` release 尚未发布 —— 通过 README 脚注澄清 "develop badge = 预计下一个 release 号"。
+- Develop 的 `README.md` badge 在预 bump 后显示 "4.6.1"，但 `v4.6.1` release 尚未发布 —— 通过 README 脚注 + CLAUDE.md Key Conventions 段澄清 "develop badge = 预计下一个 release 号"。
 - 每次 release 多 1 个 commit（预 bump commit），develop history 比 main 多一个标记位。
 - Hotfix 流程未预先处理与预 bump 的冲突，未来首次 hotfix 时需 ad-hoc 解决。
 
@@ -81,20 +85,20 @@ Boundary:
 ### §4.1 Option A: 完全不动（保持现状）
 
 - **Pros**: 零改动；现有 CHANGELOG `[Unreleased]` 已经是"是否累积"的权威信号。
-- **Cons**: 与 mj-system 心智模型不一致；维护者需记两套工作流。
-- **Why rejected**: 用户的核心诉求是跨项目对齐，"不动" 不解决该诉求。
+- **Cons**: release readiness signal 仍需 git log / CHANGELOG 二次确认；不解决 §1 Context 的 ambiguity 问题。
+- **Why rejected**: 不解决用户实际遇到的疑问场景；invariant 缺失。
 
 ### §4.2 Option B: 采用 `-dev` / `-SNAPSHOT` 后缀风格（Maven 习惯）
 
 - **Pros**: 语义最明确；develop badge 显示 "4.7.0-dev" 一眼可知是预发布。
-- **Cons**: 与 mj-system 现行风格不一致（mj-system 用 pure patch）；需放宽 `release.yml` semver 校验；CI README badge 校验逻辑需重写。
-- **Why rejected**: 偏离了 "对齐 mj-system" 的目标；改动面更大。
+- **Cons**: 需放宽 `release.yml` semver 校验（当前严格 `^\d+\.\d+\.\d+$`）；CI README badge 校验逻辑需重写；marketplace 现有 `bump-version.ps1` 也需改写 regex；改动面比 pure patch 大得多。
+- **Why rejected**: blast radius 不成比例（同等 invariant 价值，但需改 3 处 CI/script）。
 
-### §4.3 Option C: 借鉴包括 `plans/[PLAN]_Release_vX.Y.Z.md` 在内的全部 4 项机制
+### §4.3 Option C: 在预 bump 之上额外引入 `plans/[PLAN]_Release_vX.Y.Z.md` 审计文档
 
-- **Pros**: 与 mj-system 100% 同构；审计追溯最完整。
-- **Cons**: 违反 `[STANDARD]_AI_Engineering_Execution_HITL_Prompt` §4.3 ("marketplace 不维护 plans/ 目录")；与 marketplace `CHANGELOG.md` 现有详细 release narrative 形成功能重叠。
-- **Why rejected**: STANDARD 是 marketplace 工作流 single source of truth，违反它需要先发起 STANDARD revision ADR；且 CHANGELOG 已承担同等审计职能（v4.6.0 entry 即典型示例：per-PR + table + 根因 + 教训），追加 PLAN 目录是冗余成本。
+- **Pros**: 每次 release 都有独立 audit doc；追溯最完整。
+- **Cons**: 违反 `[STANDARD]_AI_Engineering_Execution_HITL_Prompt` §4.3 "marketplace 不维护 plans/ 目录"；且 marketplace `CHANGELOG.md` 现有详细 release narrative（v4.6.0 entry 含 per-PR breakdown + 4-layer defense table + root cause + lessons）已承担同等审计职能 —— 追加 `plans/` 是冗余。
+- **Why rejected**: STANDARD 是 marketplace 工作流 single source of truth，违反它需要先发起 STANDARD revision ADR；且 CHANGELOG 已覆盖 audit 需求。
 
 ### §4.4 Option D: 把 release 审计迁到 `docs/postmortem/[POSTMORTEM]_Release_vX.Y.Z.md`
 
@@ -104,7 +108,7 @@ Boundary:
 
 ## §5 Implementation Plan
 
-1. Create this ADR (in this PR)
+1. Create this ADR (in original PR #120)
 2. Update `docs/runbook/[RUNBOOK]_Release_Operations.md` v1.2 → v1.3：
    - Add §3.7 "Post-release develop 预 bump"
    - Add §6 checklist 项 "release 完成后 72h 内 develop 已预 bump"
@@ -113,7 +117,7 @@ Boundary:
 4. Update `README.md` + `CLAUDE.md` 加 develop badge 脚注
 5. Update `.claude/skills/mp-doc-bump-version/SKILL.md` 加 post-release pre-bump 使用场景
 6. Add `CHANGELOG.md` 新的空 `[Unreleased]` stub
-7. Execute first pre-bump: `pwsh ./scripts/bump-version.ps1 -From 4.6.0 -To 4.6.1`（在 this PR 中作为机制启动点）
+7. Execute first pre-bump: `pwsh ./scripts/bump-version.ps1 -From 4.6.0 -To 4.6.1`（在 PR #120 中作为机制启动点）
 8. Create `.github/workflows/verify-develop-prebumped.yml`（在 step 7 之后落地，否则该 workflow 自己引入即报 warn）
 
 Related documentation updates:
@@ -125,25 +129,25 @@ Related documentation updates:
 
 ## §6 Acceptance Criteria
 
-- [ ] `bump-version.ps1 -From 4.6.0 -To 4.6.1 -DryRun` 输出 3 文件预期变更（VERSION / marketplace.json / README.md）
-- [ ] develop 上首次预 bump commit 落地后，`git show develop:VERSION` = 4.6.1, `git show main:VERSION` = 4.6.0
-- [ ] `verify-develop-prebumped.yml` 在 develop push 时触发，输出 `OK: develop pre-bumped (main=4.6.0, develop=4.6.1)`
-- [ ] PR 模板 4 文件均含 CHANGELOG checkbox（feature/bugfix/documentation/maintain/hotfix 5 类 PR 全覆盖）
-- [ ] README + CLAUDE.md 含 develop badge 脚注，说明 "develop badge = 预计下一个 release 号"
-- [ ] RUNBOOK v1.3 §3.7 详述预 bump 步骤；§4.5 含 hotfix TODO 标记
-- [ ] CI `Validate README badge matches VERSION` 步骤在 develop 上 PR 仍 pass（badge=4.6.1 = VERSION=4.6.1）
+- [x] `bump-version.ps1 -From 4.6.0 -To 4.6.1 -DryRun` 输出 3 文件预期变更（VERSION / marketplace.json / README.md）
+- [x] develop 上首次预 bump commit 落地后，`git show develop:VERSION` = 4.6.1, `git show main:VERSION` = 4.6.0
+- [x] `verify-develop-prebumped.yml` 在 develop push 时触发，输出 `OK: develop pre-bumped`
+- [x] PR 模板 4 文件均含 CHANGELOG checkbox（feature/bugfix/documentation/maintain/hotfix 5 类 PR 全覆盖）
+- [x] README + CLAUDE.md 含 develop badge 脚注，说明 "develop badge = 预计下一个 release 号"
+- [x] RUNBOOK v1.3 §3.7 详述预 bump 步骤；§4.5 含 hotfix TODO 标记
+- [x] CI `Validate README badge matches VERSION` 步骤在 develop 上 PR 仍 pass（badge=4.6.1 = VERSION=4.6.1）
 
 ## §7 References
 
-- Issue: 无（直接 ADR 驱动；起源于用户对 develop=main 版本号的疑问）
+- Issue: 无（直接 ADR 驱动；起源于维护者对 develop=main 版本号语义的疑问）
 - Plan: `~/.claude/plans/https-github-com-mj-agentlab-mj-agentlab-velvet-moonbeam.md`
-- Reference repo: mj-system（pre-bump 模式来源；3.2.1 → 3.2.2 实例）
-- Related STANDARD: [STANDARD]_AI_Engineering_Execution_HITL_Prompt v1.4 §0.4 / §4.3（"marketplace 不维护 plans/ 目录" 约束源）
-- Related RUNBOOK: [RUNBOOK]_Release_Operations v1.2 → v1.3（本 ADR 落地后的版本）
+- Related STANDARD: `[STANDARD]_AI_Engineering_Execution_HITL_Prompt` v1.4 §0.3（独立性原则）/ §0.4（不维护 plans/ 约束）/ §4.3
+- Related RUNBOOK: `[RUNBOOK]_Release_Operations` v1.3（本 ADR 落地后的版本）
 
 ## §8 Decision Log
 
 | Date | State | By | Note |
 |------|-------|----|------|
-| 2026-05-18 | proposed | ranzuozhou | 初稿；4 选项分析；选定 Option C 之外的 3 机制借鉴方案 |
-| 2026-05-18 | accepted | ranzuozhou | 用户确认借鉴 3 机制 + drop release plan doc；执行 Implementation Plan |
+| 2026-05-18 | proposed | ranzuozhou | 初稿；4 选项分析 |
+| 2026-05-18 | accepted | ranzuozhou | 用户确认 3 机制 + drop release plan doc；执行 Implementation Plan（PR #120）|
+| 2026-05-18 | revised | ranzuozhou | v1.0 → v1.1: scrub 外部项目引用 per STANDARD §0.3（独立性原则）；技术决策不变（follow-up PR）|

--- a/docs/runbook/[RUNBOOK]_Release_Operations.md
+++ b/docs/runbook/[RUNBOOK]_Release_Operations.md
@@ -1,12 +1,12 @@
 ---
 type: runbook
 scope: marketplace
-summary: 从功能开发到版本发布的完整操作流程 — Issue → PR → Release → Post-release develop pre-bump (v1.3 起借鉴 mj-system pre-bump 机制)
+summary: 从功能开发到版本发布的完整操作流程 — Issue → PR → Release → Post-release develop pre-bump (v1.3 起 §3.7 落地)
 owner: marketplace-maintainers
 created: 2026-03-17
 updated: 2026-05-18
 state: active
-version: v1.3
+version: v1.3.1
 last-verified: 2026-05-18
 domain: release
 tags:
@@ -20,7 +20,8 @@ related:
   - ../rule/[STANDARD]_AI_Engineering_Execution_HITL_Prompt.md
   - ../adr/[ADR]_Develop_PreBump_Adoption.md
 revision: |
-  2026-05-18 — v1.3: **借鉴 mj-system develop post-release 预 bump 机制** (per `[ADR]_Develop_PreBump_Adoption`)。新增 §3.7 "Post-release develop 预 bump"（sync-main-to-develop 完成后即在 develop 上执行 `bump-version.ps1 -From X.Y.Z -To X.Y.(Z+1)` 一个 commit；pure patch 风格无 `-dev` 后缀；只 bump 顶层 VERSION，不连带 plugin.json）；§4.5 加 hotfix 与预 bump 冲突 TODO 标记（暂不预设处理，待首次 hotfix 事件再补 §4.6）；§6 发布前检查清单加 1 项后置 "release 完成后 72h 内 develop 已预 bump"。Configures `verify-develop-prebumped.yml` warn-only CI 作为遗忘提醒兜底（72h 宽限）。Non-trigger archive（minor bump，无 Framework §2.3.1 触发条件）。
+  2026-05-18 — v1.3.1: scrub external project references per `[STANDARD]_AI_Engineering_Execution_HITL_Prompt` §0.3 independence principle (frontmatter summary + this revision line + §3.7 "Why" callout reworded)；technical procedure 不变。
+  2026-05-18 — v1.3: 引入 develop post-release 预 bump 机制 (per `[ADR]_Develop_PreBump_Adoption`)。新增 §3.7 "Post-release develop 预 bump"（sync-main-to-develop 完成后即在 develop 上执行 `bump-version.ps1 -From X.Y.Z -To X.Y.(Z+1)` 一个 commit；pure patch 风格无 `-dev` 后缀；只 bump 顶层 VERSION，不连带 plugin.json）；§4.5 加 hotfix 与预 bump 冲突 TODO 标记（暂不预设处理，待首次 hotfix 事件再补 §4.6）；§6 发布前检查清单加 1 项后置 "release 完成后 72h 内 develop 已预 bump"。Configures `verify-develop-prebumped.yml` warn-only CI 作为遗忘提醒兜底（72h 宽限）。Non-trigger archive（minor bump，无 Framework §2.3.1 触发条件）。
   2026-05-18 — v1.2: **CLAUDE.md 自动化 sync**（closes #110）。§3.2.1 post-bump verification 第 2 步 wording 从 "CLAUDE.md plugin line manual：script 不 cover" 改为 "script 已 cover (v2 起)；保留 grep verify 作为 last-line defense"；§6 发布前检查清单第 3 项 wording 同步更新；cross-reference 加 PR #115 (Issue #110 closure) + 内含 marketplace.json `[^}]*` regex bug 顺手修复（描述含 `}` 时 silent SKIP，已修为 `[\s\S]*?` 非贪婪）。bump-version.ps1 现 cover 全 5 Quintangle sites，三层防御 (script 覆盖 + CI guard + RUNBOOK MANDATORY) 完工。Non-trigger archive（minor bump，无 Framework §2.3.1 触发条件）。
   2026-05-18 — v1.1: **bump-version.ps1 MANDATORY enforcement**（closes #111）。§3.2 重写为 MANDATORY callout（不再是 advisory）+ 新增 §3.2.1 post-bump verification step（`git diff --name-only` 必须含 `README.md` + Quintangle 5-site sed-based check）；§3.4 git add 列表新增 `README.md` + `CLAUDE.md` + commit message 改 release scope 范例；§6 发布前检查清单新增 3 项 NEW（script 已运行 / diff 含 README / CLAUDE.md plugin line 同步）+ 发布后新增 1 项（visual badge verify）；§7 新增 版本历史段（§8 即原 §7 相关文档）；fix line 350 `../CONTRIBUTING.md` → `../guide/[GUIDE]_Contributing.md` (PR #103 rename)；cross-reference v4.6.0 CI guard «Validate README badge matches VERSION»（PR #109）作为 safety net + Issue #110 / #113 future-work 锚点
   2026-03-17 — v1.0: 初版
@@ -305,7 +306,7 @@ gh release view v1.1.0
 > [!IMPORTANT]
 > **MANDATORY 但宽限 72h**：每次 release 完成 + sync-main-to-develop PR 合并后，需在 develop 上执行一次预 bump，把 `VERSION` 推到下一个 patch（e.g., 4.6.0 → 4.6.1）。
 >
-> **为什么需要**：让 `develop VERSION > main VERSION` 始终成立，肉眼可见 "develop 是否领先 main"；与 [mj-system](https://github.com/MJ-AgentLab/mj-system) 工作流对齐。详见 [`[ADR]_Develop_PreBump_Adoption`](../adr/[ADR]_Develop_PreBump_Adoption.md)。
+> **为什么需要**：让 `develop VERSION > main VERSION` 始终成立，肉眼可见 "develop 是否领先 main"，回答 release readiness 不再需要 git log / CHANGELOG 二次确认。详见 [`[ADR]_Develop_PreBump_Adoption`](../adr/[ADR]_Develop_PreBump_Adoption.md) §1 Context + §3.1 Positive。
 >
 > **Safety net**：`.github/workflows/verify-develop-prebumped.yml` 在 release 后 72h 仍未预 bump 时输出 workflow summary 警告（warn-only，永不阻塞）。
 
@@ -437,7 +438,8 @@ git push origin --delete v1.1.0
 
 ## 7. 版本历史
 
-- **v1.3**（2026-05-18）：**借鉴 mj-system develop post-release 预 bump 机制**（per `[ADR]_Develop_PreBump_Adoption`）。新增 §3.7 "Post-release develop 预 bump" — sync-main-to-develop 完成后在 develop 上执行 `bump-version.ps1 -From X.Y.Z -To X.Y.(Z+1)` 一个 commit；pure patch 风格无 `-dev` 后缀；只 bump 顶层 VERSION，不连带 plugin.json。§4.5 加 hotfix 与预 bump 冲突 TODO 标记（暂不预设处理，待首次 hotfix 事件再补 §4.6）。§6 发布后检查清单加 1 项 "72h 内完成预 bump"。配套 `.github/workflows/verify-develop-prebumped.yml` warn-only CI 在 72h 宽限外提醒。Frontmatter v1.2 → v1.3 + revision block + 加 `[ADR]_Develop_PreBump_Adoption` 到 related。Non-trigger archive（minor bump，无 Framework §2.3.1 触发条件）。
+- **v1.3.1**（2026-05-18）：scrub 外部项目引用 per `[STANDARD]_AI_Engineering_Execution_HITL_Prompt` §0.3 独立性原则；frontmatter summary + revision + §3.7 "为什么需要" callout reworded；技术流程 (§3.7 / §4.5 / §6 / `verify-develop-prebumped.yml`) 完全不变。Non-trigger archive。
+- **v1.3**（2026-05-18）：引入 develop post-release 预 bump 机制（per `[ADR]_Develop_PreBump_Adoption`）。新增 §3.7 "Post-release develop 预 bump" — sync-main-to-develop 完成后在 develop 上执行 `bump-version.ps1 -From X.Y.Z -To X.Y.(Z+1)` 一个 commit；pure patch 风格无 `-dev` 后缀；只 bump 顶层 VERSION，不连带 plugin.json。§4.5 加 hotfix 与预 bump 冲突 TODO 标记（暂不预设处理，待首次 hotfix 事件再补 §4.6）。§6 发布后检查清单加 1 项 "72h 内完成预 bump"。配套 `.github/workflows/verify-develop-prebumped.yml` warn-only CI 在 72h 宽限外提醒。Frontmatter v1.2 → v1.3 + revision block + 加 `[ADR]_Develop_PreBump_Adoption` 到 related。Non-trigger archive（minor bump，无 Framework §2.3.1 触发条件）。
 - **v1.2**（2026-05-18）：**CLAUDE.md 自动化 sync**（closes #110）。§3.2.1 第 2 步 + §6 第 3 项 wording 从「manual / script 不 cover」更新为「script 已 cover (v2 起 plugin scope 含 CLAUDE.md scoped-regex 分支)；grep 保留作 last-line defense」。配套 PR #115 同时修了 `scripts/bump-version.ps1` 中 marketplace.json `[^}]*` regex bug（描述含 `}` 时 silent SKIP）。bump-version.ps1 现真正 cover 全 5 Quintangle sites，三层防御 (script 覆盖 + CI guard + RUNBOOK MANDATORY) 完工。Frontmatter v1.1 → v1.2 + revision block。Non-trigger archive。
 - **v1.1**（2026-05-18）：**bump-version.ps1 MANDATORY enforcement**（closes #111）。§3.2 改 advisory → MANDATORY callout box + 加 §3.2.1 post-bump verification（git diff README.md 必含 + Quintangle 5-site 一致性 sed-based check）；§3.4 git add 列表加 `README.md` + `CLAUDE.md` + 强调 release scope + 跨引用本地 `validate-commits.sh`；§6 发布前检查清单加 3 项 NEW + 发布后加 1 项 visual badge verify；§8 即原 §7 相关文档；fix line 350 `../CONTRIBUTING.md` → `../guide/[GUIDE]_Contributing.md` (PR #103 rename)；cross-reference v4.6.0 CI guard «Validate README badge matches VERSION»（PR #109）作为 safety net + Issue #110 / #113 future-work 锚点。Frontmatter v1.0 → v1.1 + revision block。Non-trigger archive（minor bump，无 Framework §2.3.1 触发条件）。
 - **v1.0**（2026-03-17）：初版。Issue → Branch → Develop → Commit → PR → CI → Merge → Release 完整 6 阶段操作流程 + hotfix + rollback 子流程。


### PR DESCRIPTION
## 文档变更内容

PR #120 在落地 develop pre-bump 机制时，在 ADR / RUNBOOK / CHANGELOG / INDEX 四个 governance surface 引入了对外部项目 `mj-system` 的引用（共 16 处新增）。本 PR scrub 这些引用，以 marketplace-internal 理据重新 framing，**技术决策与实施细节完全不变**。

涉及 4 文件 / 3 commits / +64 -56 lines：

| File | 改动 |
|------|------|
| `docs/adr/[ADR]_Develop_PreBump_Adoption.md` | v1.0 → v1.1；重写 §1 / §2 / §3.1 / §4 (4 options) / §7 References；§5 Implementation Plan + §6 AC 保持原状（已 [x] 标记验证完成）|
| `docs/runbook/[RUNBOOK]_Release_Operations.md` | v1.3 → v1.3.1；frontmatter summary + revision block + §3.7 "为什么需要" callout reworded；§7 加 v1.3.1 history line；procedural content (§3.7 步骤 / §4.5 TODO / §6 checklist) 完全不变 |
| `CHANGELOG.md` | `[Unreleased]` 段 5 个新 entries reworded；historical entries (>L100) **未触动**（revisionist removal 会扭曲历史）|
| `docs/INDEX.md` | v4.6 → v4.6.1；ADR row description scrub |

## 变更原因

`[STANDARD]_AI_Engineering_Execution_HITL_Prompt` v1.4 §0.3 明确规定：

> 任何新章节必须保留 marketplace 独立性原则（**不引用外部项目**）

v1.4 revision block 进一步声明 "**移除所有 cross-project 引用**以满足 marketplace 文档体系独立性原则（Framework v1.5）"。

PR #120 的执行过程**未 grep `mj-system`** 验证新增 governance 文档是否含外部项目引用 —— 这是 self-review checklist item 12 的漏检（应补 "scan new governance docs against §0.3 independence principle"）。本 PR 修复该 regression。

## 自检结果

- [x] 文件命名符合 [`[STANDARD]_Documentation_Framework.md`](../../docs/rule/[STANDARD]_Documentation_Framework.md) §2.4（无 `_vX.Y` 后缀；ADR + RUNBOOK + INDEX 路径不变）
- [x] frontmatter 含 8 必需字段（ADR v1.1 / RUNBOOK v1.3.1 / INDEX v4.6.1 均完整）
- [x] 文件位于正确子目录（ADR `docs/adr/` / RUNBOOK `docs/runbook/` / INDEX 根；未移动文件）
- [x] markdown 风格符合 [`[STANDARD]_GitHub_Markdown.md`](../../docs/rule/[STANDARD]_GitHub_Markdown.md)（保留 ATX headings / GFM tables / native alerts）
- [x] 内部链接有效（ADR / RUNBOOK / INDEX 之间的相对路径不变）
- [x] `docs/INDEX.md` 已同步更新（ADR row description + frontmatter version）
- [x] CLAUDE.md 未触动（无文档结构变更，仅文字 scrub）
- [x] Commit message 符合 [`[STANDARD]_Commit_Message_Convention.md`](../../docs/rule/[STANDARD]_Commit_Message_Convention.md)（3 commits 全 `docs` 类型；scope 分别 `docs-adr` / `docs-runbook` / `marketplace`；`validate-commits.sh` 输出 `[OK] 3 commit(s) validated; 0 failures`）
- [x] CHANGELOG.md `[Unreleased]` 区块已更新（reframed + 加 1 个 Changed entry 描述本 scrub）

## 本地验证

```bash
$ # 4 surfaces 全部 0 hits
$ grep -c "mj-system" docs/adr/[ADR]_Develop_PreBump_Adoption.md
0
$ grep -c "mj-system" docs/runbook/[RUNBOOK]_Release_Operations.md
0
$ head -25 CHANGELOG.md | grep -c "mj-system"
0
$ grep -c "mj-system" docs/INDEX.md
0

$ # 历史 CHANGELOG entries 数量保持（pre-existing 16 historical refs preserved）
$ grep -c "mj-system" CHANGELOG.md
16
$ # baseline 比对（origin/develop 含 PR #120 新增 5 = 总 18）
$ git show origin/develop:CHANGELOG.md | grep -c "mj-system"
18
$ # 净差 -2（5 新增 - 3 reworded preserved）

$ bash scripts/validate-commits.sh origin/develop..HEAD
[OK] 3 commit(s) validated in range 'origin/develop..HEAD'; 0 failures
```

## 风险

- **零功能风险**：纯文档 scrub，无 VERSION / CI / script / plugin 改动；CI badge 校验、版本 quintangle invariant、verify-develop-prebumped.yml 全部不受影响。
- ADR § Decision Log 加 1 行 revised state；ADR `version: v1.0 → v1.1` 是首次 ADR 修订（marketplace 历史上 ADR 多直接 archive，无 in-place revision 先例），但 frontmatter version 字段早就支持，符合 Framework convention。

## 历史 CHANGELOG 引用未触动的理由

CHANGELOG body >L100 保留 13 处 historical mj-system 引用：

- 大多在 `## [3.0.0]` / `## [v3.x.y]` 段描述 v3.0.0 marketplace genericization 的具体事件（5 个 mj-sys-* 插件被删 / mj-nlm rename 等）
- `PR #104` entry 自身就是 "Marketplace independence audit cleanup — mj-system / mj-agent cross-project references purged in scope"，证明这是项目长期独立性整治的一部分
- 删除这些会**扭曲历史**：CHANGELOG 是 immutable record，记录 "what happened"，不是 "current state"

STANDARD §0.3 独立性原则适用于 **新增 governance content**，不适用于 historical narrative。
