### PR TITLE
infra: harden bulk-cleanup against 3 traps (post 2026-05-18 P3 incident)

### DIFF
--- a/.claude/skills/mp-git-cleanup/SKILL.md
+++ b/.claude/skills/mp-git-cleanup/SKILL.md
@@ -130,6 +130,131 @@ git tag -l "v$(cat VERSION)"   # 验证当前版本 tag 存在
 
 仅 release PR 后才会有新 tag；其他 PR 这一步是 no-op，但仍跑（确保本地 tag 索引与 remote 同步）。
 
+## Bulk Cleanup Mode
+
+> [!IMPORTANT]
+> Single-PR cleanup (Steps 1-7 above) 处理一个 worktree 一次。当用户说 **"bulk cleanup" / "清理一批分支" / "post-multi-release cleanup" / "清所有 merged 分支"** 时，进入本 mode —— 它有 3 个非显然的 trap，必须显式处理，否则会误删 protected branch 或漏删 remote。
+
+### 何时进入
+
+- 累积多个 cycle 后批量清残余（典型：>5 分支待删）
+- 项目刚启用 GitHub `delete_branch_on_merge=true` 前留下的孤儿
+- audit 报告 / 用户明确要求批量
+
+### 3 Traps（必读，含 2026-05-18 incident 实证）
+
+完整事故分析见 [`../../../docs/postmortem/[POSTMORTEM]_2026-05-18_Bulk_Cleanup_Trap_Analysis.md`](../../../docs/postmortem/[POSTMORTEM]_2026-05-18_Bulk_Cleanup_Trap_Analysis.md)。
+
+#### Trap #1：`git branch` 输出前缀 `+` 漏过滤
+
+Bare repo + worktree 模式下，`git branch` 输出前缀有 3 种：
+
+| Prefix | 含义 |
+|--------|------|
+| `  ` (2 空格) | 普通本地分支 |
+| `* ` | 当前 worktree 当前分支 |
+| `+ ` | **被另一个 worktree 占用**（含 `.bare/` 持有 `main`） |
+
+错误写法（会漏 `+ main`）:
+
+```bash
+git branch --merged develop | grep -v -E '^\s*\*?\s*(main|develop)$' | xargs git branch -d
+# `+ main` 不匹配 → 泄漏到 xargs → `git branch -d + main` → 误删 main
+```
+
+正确写法：
+
+```bash
+git branch --merged develop | grep -v -E '^[ *+] +(main|develop)$' | xargs -r git branch -d
+# [ *+] 字符类覆盖全部 3 种前缀
+```
+
+更稳：
+
+```bash
+git for-each-ref refs/heads/ --format='%(refname:short)' | grep -v -E '^(main|develop)$' | xargs -r git branch -d
+# for-each-ref 输出无 prefix
+```
+
+如果不小心删了 `main` / `develop`：`git branch <name> origin/<name>` 即刻恢复（commit 历史 + remote 不受影响）。
+
+#### Trap #2：Local 删 ≠ Remote 删
+
+`git branch -d` **只删本地**。远端 ref 必须显式 `git push origin --delete <name>` 或依赖 GitHub `delete_branch_on_merge=true` repo setting。
+
+**v4.6.2+ 现状**：marketplace 已启用 `delete_branch_on_merge=true`，**single-PR merge 后 head 分支自动删**，无需手动 push --delete。
+
+**Bulk mode 例外**：清历史遗留孤儿（GitHub 设置启用之前累积的）仍需手动:
+
+```bash
+# 列 remote 孤儿（已不在 local 但仍在 origin）
+git fetch --prune origin
+git branch -r | grep -v -E '(HEAD|origin/(main|develop)$)' | sed 's|origin/||' | tr -d ' '
+
+# 批量删
+git branch -r | grep -v -E '(HEAD|origin/(main|develop)$)' | sed 's|origin/||' | tr -d ' ' | xargs -r -I {} git push origin --delete {}
+```
+
+不要假设 "audit 显示 local + remote 同名 = 删 local 就够"；必须独立确认 remote 状态。
+
+#### Trap #3：Windows Git Bash 的 `gh api` leading-slash 改写
+
+MSYS2 path translation 把任何以 `/` 开头的 CLI 参数视为 POSIX 路径并改写为 Windows 路径。
+
+错误（Git Bash 报 `invalid API endpoint: "C:/Program Files/Git/repos/..."`）:
+
+```bash
+gh api -X PATCH /repos/owner/repo -f delete_branch_on_merge=true
+```
+
+正确（去 leading slash）:
+
+```bash
+gh api -X PATCH repos/owner/repo -f delete_branch_on_merge=true
+```
+
+影响所有带 leading-slash endpoint 的 `gh api` 调用（含 GET）。Linux/macOS 上 leading slash 仍可用，但**统一去掉是更安全的写法**。
+
+### Pre-flight 4-check（执行前必跑）
+
+```bash
+# 1. 未合并分支必须为空
+git branch --no-merged develop
+# 空 → OK；非空 → STOP 排查 unmerged 工作
+
+# 2. 无 open PR
+gh pr list -R MJ-AgentLab/mj-agentlab-marketplace --state open
+# 空 → OK；非空 → STOP，等 PR 合并或关闭
+
+# 3. worktree 仅 protected
+git worktree list
+# 期望仅 .bare + develop；额外 worktree → 先 single-PR cleanup 它们
+
+# 4. dry-run 候选列表（先 cat，不要直接 xargs）
+git for-each-ref refs/heads/ --format='%(refname:short)' | grep -v -E '^(main|develop)$' | tee /tmp/candidates.txt
+wc -l /tmp/candidates.txt
+# 肉眼扫描确认无 main/develop 泄漏
+```
+
+任一不符 → 立即 STOP，不进入删除阶段。
+
+### 推荐工具：`scripts/safe-bulk-cleanup.ps1`
+
+项目自带的安全 bulk cleanup 脚本，封装上述 pre-flight 4-check + Trap-aware 删除 + dry-run-default + 多重 protected-branch refusal。
+
+```powershell
+# Dry-run（默认；不删任何东西，仅输出候选清单 + 预期命令）
+pwsh ./scripts/safe-bulk-cleanup.ps1
+
+# 删本地候选
+pwsh ./scripts/safe-bulk-cleanup.ps1 -Apply
+
+# 删本地 + remote 孤儿
+pwsh ./scripts/safe-bulk-cleanup.ps1 -Apply -IncludeRemote
+```
+
+详见 script 自带 `.SYNOPSIS` + `.DESCRIPTION`。
+
 ## Output Format
 
 ```markdown
@@ -173,7 +298,7 @@ git tag -l          # 期望: 含新 tag (if release PR)
 
 ## What This Skill DOES NOT DO
 
-- ❌ 不删 remote branch (GitHub 保留 history)
+- ❌ Single-PR mode 不显式删 remote branch（v4.6.2+ GitHub `delete_branch_on_merge=true` 已 cover 自动删；Bulk mode 例外见上 §Bulk Cleanup Mode → Trap #2）
 - ❌ 不删 develop / main worktree
 - ❌ 不 `rm -rf` worktree（用 `git worktree remove`）
 - ❌ 不删未合并 branch（除非用户强烈确认 + force flag）
@@ -198,8 +323,10 @@ git tag -l          # 期望: 含新 tag (if release PR)
 - **不要** 用 `rm -rf <worktree>` （留 stale metadata 在 bare repo `.bare/worktrees/<name>/`）
 - **不要** 删 develop / main worktree
 - **不要** `git branch -D` 未合并 branch（先 `gh pr view` 确认 MERGED）
-- **不要** 同时删 remote branch（让 GitHub 保留 history）
 - **不要** 跳 `git fetch --tags`（错过 release.yml tag）
+- **(Bulk mode)** **不要** 用 `\s*\*?` 过滤 git branch 输出 — 会漏 `+ main` 前缀；用 `[ *+]` 字符类或 `git for-each-ref`（详 §Bulk Cleanup Mode → Trap #1）
+- **(Bulk mode)** **不要** 假设删 local 就等于删 remote — 两者独立 ref 命名空间，需单独 `git push origin --delete` 或依赖 GitHub auto-delete 设置（详 §Bulk Cleanup Mode → Trap #2）
+- **(Windows)** **不要** 给 `gh api` endpoint 加 leading slash — Git Bash MSYS 改写会破坏 endpoint（详 §Bulk Cleanup Mode → Trap #3）
 
 ## Handoff to Next Stage
 

--- a/.claude/skills/mp-git-merge-gate/SKILL.md
+++ b/.claude/skills/mp-git-merge-gate/SKILL.md
@@ -93,6 +93,9 @@ gh pr view $PR --json comments
 gh api repos/MJ-AgentLab/mj-agentlab-marketplace/pulls/$PR/comments
 ```
 
+> [!note]
+> **Windows / Git Bash users**: omit leading slash in `gh api` endpoints (`gh api repos/...` not `gh api /repos/...`). MSYS path translation rewrites the leading slash into a Windows path (`C:/Program Files/Git/repos/...`), breaking the endpoint. Detailed reproducer + fix: [`mp-git-cleanup` SKILL §Bulk Cleanup Mode → Trap #3](../mp-git-cleanup/SKILL.md#trap-3windows-git-bash-的-gh-api-leading-slash-改写).
+
 **判断**:
 - `APPROVED` 且无 unresolved comment → 可继续
 - `CHANGES_REQUESTED` → NOT READY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@
 
 ## [Unreleased]
 
-_(no in-flight changes at release-cut time)_
+### Added
+
+- **`docs/postmortem/[POSTMORTEM]_2026-05-18_Bulk_Cleanup_Trap_Analysis.md`** — 项目首份 POSTMORTEM 文档（填补 Framework v1.5 §2.4 `docs/postmortem/` placeholder）。记录 2026-05-18 bulk branch cleanup 触发的 3 个 trap：(1) `git branch` `+` 前缀漏过滤导致 local `main` 误删；(2) local `git branch -d` 不动 remote，audit 用语 "sync with" 歧义误导；(3) Windows Git Bash 把 `gh api /repos/...` 改写成 Windows 路径。Severity P3（恢复，0 数据丢失）。
+- **`scripts/safe-bulk-cleanup.ps1`** — 安全 bulk cleanup 脚本。封装 pre-flight 4-check + 3-trap-aware 删除：使用 `git for-each-ref`（避开 Trap #1 前缀问题）+ 多层 protected-branch refusal + dry-run-default（必须显式 `-Apply`）+ opt-in `-IncludeRemote`。镜像 `bump-version.ps1` 风格（StrictMode + 彩色输出 + `.SYNOPSIS`/`.DESCRIPTION` 注释块）。
+- **`.claude/skills/mp-git-cleanup/SKILL.md`** §Bulk Cleanup Mode — 新章节（在 Step 7 之后）。3 traps inline 含错误/正确写法对照 + Pre-flight 4-check + 指向 `safe-bulk-cleanup.ps1`；revised "DOES NOT DO" 反映 GitHub `delete_branch_on_merge=true` v4.6.2+ 启用现实；扩 Anti-patterns 加 3 条 (Bulk mode) / (Windows) 项目。
+
+### Changed
+
+- **`docs/runbook/[RUNBOOK]_Release_Operations.md`** v1.3.1 → v1.3.2 — §2.6 + §3.7 加 cleanup callout box，指向 mp-git-cleanup §Bulk Cleanup Mode + `safe-bulk-cleanup.ps1`；frontmatter `related[]` 加 POSTMORTEM_2026-05-18 引用。Procedural commands 完全不变。
+- **`.claude/skills/mp-git-merge-gate/SKILL.md`** Step 4 — 加 Windows Git Bash 警告 callout (`gh api` 端点 leading slash 改写)。
+- **`docs/guide/[GUIDE]_Contributing.md`** v1.0 → v1.1 — §Bare Repo + Worktree 加 "`git branch` 输出前缀（worktree 模式特有）" 子段，列 3 prefix (`  ` / `* ` / `+ `) 含义 + 过滤脚本必须用 `[ *+]` 警告 + 交叉引用 mp-git-cleanup §Bulk Mode + POSTMORTEM。
 
 ## [4.6.1] - 2026-05-18
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -6,7 +6,7 @@ owner: marketplace-maintainers
 created: 2026-05-15
 updated: 2026-05-18
 state: active
-version: v4.6.1
+version: v4.6.2
 domain: governance
 tags:
   - index
@@ -14,6 +14,7 @@ tags:
 related:
   - ./rule/[STANDARD]_Documentation_Framework.md
 revision: |
+  2026-05-18 — v4.6.2: add first [POSTMORTEM] row (2026-05-18 Bulk Cleanup Trap Analysis, P3); update [RUNBOOK]_Release_Operations row to mention v1.3.2 cleanup callouts; update [GUIDE]_Contributing row to mention v1.1 worktree prefix note
   2026-05-18 — v4.6.1: scrub external project reference from [ADR]_Develop_PreBump_Adoption row description per `[STANDARD]_AI_Engineering_Execution_HITL_Prompt` §0.3
   2026-05-18 — v4.6: add [ADR]_Develop_PreBump_Adoption row + update RUNBOOK_Release_Operations row to mention v1.3 §3.7 pre-bump
   2026-05-18 — v4.5: add 8-field frontmatter (Framework v1.5 §1 INDEX special clause); update Framework v1.4→v1.5 + HITL v1.3→v1.4 + learn-kit 1.1.0→1.2.0 entries; remove deleted ai_engineering_execution_hitl_workflow.md row; move Exemption Review ADR to Archived section; add Exemption Reversal ADR; update CONTRIBUTING + MIGRATION_GUIDE paths to docs/guide/; update plugin-internal teaching series description to reflect 6→2 consolidation
@@ -38,7 +39,7 @@ Navigation hub for all marketplace documentation.
 
 | Document | Description |
 |----------|-------------|
-| [Contributing Guide](./guide/[GUIDE]_Contributing.md) | 贡献入口；commit 段引用 Commit Message Convention（v4.5.0 起从 docs/CONTRIBUTING.md rename）|
+| [Contributing Guide](./guide/[GUIDE]_Contributing.md) | 贡献入口；commit 段引用 Commit Message Convention（v4.5.0 起从 docs/CONTRIBUTING.md rename；v1.1 起 §Bare Repo + Worktree 加 `git branch` 前缀说明）|
 | [Migration From v3 to v4](./guide/[GUIDE]_Migration_From_v3_to_v4.md) | 版本升级迁移指引（v2.x → v3.0.0；v3.2.x → v4.0.0；v4.0.0 → v4.3.x；v4.4.x → v4.5.0；v4.5.0 起从 docs/MIGRATION_GUIDE.md rename）|
 | [Marketplace Project Overview](./guide/[GUIDE]_Marketplace_Project_Overview.md) | 项目架构、插件目录、CI/CD 体系、开发环境搭建 |
 | [Plugin Development Testing Workflow](./guide/[GUIDE]_Plugin_Development_Testing_Workflow.md) | 跨仓库插件开发测试的三阶段工作流 |
@@ -49,7 +50,7 @@ Navigation hub for all marketplace documentation.
 
 | Document | Description | Last verified |
 |----------|-------------|---------------|
-| [Release Operations](./runbook/[RUNBOOK]_Release_Operations.md) | 从开发到发布的完整操作流程（Issue → PR → Release）；v1.1 起 §3.2 bump-version.ps1 MANDATORY；v1.2 起 §3.2.1 反映 CLAUDE.md script 已 cover (closes #110)；v1.3 起 §3.7 add Post-release develop pre-bump (per [`[ADR]_Develop_PreBump_Adoption`](./adr/[ADR]_Develop_PreBump_Adoption.md)) | 2026-05-18 |
+| [Release Operations](./runbook/[RUNBOOK]_Release_Operations.md) | 从开发到发布的完整操作流程（Issue → PR → Release）；v1.1 起 §3.2 bump-version.ps1 MANDATORY；v1.2 起 §3.2.1 反映 CLAUDE.md script 已 cover (closes #110)；v1.3 起 §3.7 add Post-release develop pre-bump (per [`[ADR]_Develop_PreBump_Adoption`](./adr/[ADR]_Develop_PreBump_Adoption.md))；v1.3.2 起 §2.6 + §3.7 加 cleanup callout 指向 mp-git-cleanup §Bulk Mode + safe-bulk-cleanup.ps1 | 2026-05-18 |
 | [Doc Archive Procedure](./runbook/[RUNBOOK]_Doc_Archive_Procedure.md) | 4-phase 文档归档工作流 + 2 HITL gate（per Documentation Framework v1.4 §2.3，flat layout）| 2026-05-17 |
 
 ## Architecture Decision Records (`docs/adr/`)
@@ -71,7 +72,9 @@ Navigation hub for all marketplace documentation.
 
 ## Postmortems (`docs/postmortem/`)
 
-*暂无 postmortem 记录*
+| Document | Severity | Date | Description |
+|----------|----------|------|-------------|
+| [POSTMORTEM: 2026-05-18 Bulk Cleanup Trap Analysis](./postmortem/[POSTMORTEM]_2026-05-18_Bulk_Cleanup_Trap_Analysis.md) | P3 | 2026-05-18 | Bulk branch cleanup 触发 3 个 trap (regex prefix / local-remote 对称性 / Windows gh api leading slash)；恢复无数据丢失；6 fix-sites 已落地 |
 
 ## Archived Documents (`docs/archive/`)
 

--- a/docs/guide/[GUIDE]_Contributing.md
+++ b/docs/guide/[GUIDE]_Contributing.md
@@ -6,7 +6,7 @@ owner: marketplace-maintainers
 created: 2026-03-16
 updated: 2026-05-18
 state: active
-version: v1.0
+version: v1.1
 domain: governance
 tags:
   - contributing
@@ -17,6 +17,7 @@ related:
   - ../rule/[STANDARD]_AI_Engineering_Execution_HITL_Prompt.md
   - ./[GUIDE]_Migration_From_v3_to_v4.md
 revision: |
+  2026-05-18 — v1.1: §Bare Repo + Worktree 加 "`git branch` 输出前缀（worktree 模式特有）" 子段，列出 3 种前缀 (`  ` / `* ` / `+ `) 含义 + 过滤脚本必须用 `[ *+]` 字符类的警告；交叉引用 mp-git-cleanup §Bulk Cleanup Mode + POSTMORTEM_2026-05-18。源于 2026-05-18 bulk cleanup 误删 main local ref 的 P3 incident。Non-trigger archive。
   2026-05-18 — v1.0: rename docs/CONTRIBUTING.md → docs/guide/[GUIDE]_Contributing.md + 加 frontmatter（Framework v1.5 §1 cancel single-file exemption）；fix 4 处 rule/ 相对路径；移除 cross-project 引用
 ---
 
@@ -153,6 +154,20 @@ mj-agentlab-marketplace/
 ├── feature/     # feature 分支 worktree
 └── main/        # main worktree
 ```
+
+### `git branch` 输出前缀（worktree 模式特有）
+
+`git branch` 在 bare repo + worktree 模式下输出 3 种前缀：
+
+| Prefix | 含义 |
+|--------|------|
+| `  ` (2 空格) | 普通本地分支，未 checked out |
+| `* ` | 当前 worktree 当前分支 |
+| `+ ` | **被另一个 worktree 占用**（含 `.bare/` 持有 `main`） |
+
+任何过滤 `git branch` 输出的脚本必须用 `[ *+]` 字符类，否则 `+ <branch>` 行会泄漏到下游命令（`xargs git branch -d` 等），可能误删 protected 分支。更稳的写法是 `git for-each-ref refs/heads/ --format='%(refname:short)'`（无 prefix）。
+
+bulk cleanup 时的完整 3-trap 列表见 [`.claude/skills/mp-git-cleanup/SKILL.md`](../../.claude/skills/mp-git-cleanup/SKILL.md) §Bulk Cleanup Mode 与 [`./docs/postmortem/[POSTMORTEM]_2026-05-18_Bulk_Cleanup_Trap_Analysis.md`](../postmortem/[POSTMORTEM]_2026-05-18_Bulk_Cleanup_Trap_Analysis.md)。
 
 ## Git Hooks
 

--- a/docs/postmortem/[POSTMORTEM]_2026-05-18_Bulk_Cleanup_Trap_Analysis.md
+++ b/docs/postmortem/[POSTMORTEM]_2026-05-18_Bulk_Cleanup_Trap_Analysis.md
@@ -1,0 +1,124 @@
+---
+type: postmortem
+scope: marketplace
+summary: Bulk branch cleanup (2026-05-18) 触发 3 个 trap — regex prefix / local-remote 对称性 / Windows gh api leading slash
+owner: ranzuozhou
+created: 2026-05-18
+updated: 2026-05-18
+state: active
+version: v1.0
+severity: P3
+incident-date: 2026-05-18
+resolved-at: 2026-05-18T05:10:00Z
+related:
+  - ../runbook/[RUNBOOK]_Release_Operations.md
+---
+
+# [POSTMORTEM] 2026-05-18 Bulk Cleanup Trap Analysis
+
+| Field | Value |
+|-------|-------|
+| Severity | **P3** (recovered, no data loss, no user impact) |
+| Incident date | 2026-05-18 |
+| Detected at | 2026-05-18 04:55 UTC (mid-execution) |
+| Resolved at | 2026-05-18 05:10 UTC |
+| Duration | ~15 min (regex bug recovery + 2nd remote pass + Windows endpoint retry) |
+| Affected | 1 maintainer (ranzuozhou) extra effort; local `main` ref briefly missing |
+
+## §1 Summary
+
+执行 marketplace 仓库一次性 bulk cleanup（PR #119-#124 cycle 后累积的 33 local + 38 remote merged 分支），过程中触发 3 个非显然的 trap：
+
+1. `git branch --merged` filter regex 漏掉 `+ main` 前缀，导致 `main` 本地 ref 被 `xargs git branch -d` 误删（即刻 `git branch main origin/main` 恢复，remote 从未受影响）。
+2. 原 Explore agent audit 用 "All 40 remote sync with local" 措辞，导致首次只 push --delete 5 个远端孤儿，遗漏 33 个，需第二轮补删。
+3. Windows Git Bash 把 `gh api -X PATCH /repos/...` 中的 leading slash 改写成 `C:/Program Files/Git/repos/...`，端点失败 1 次。
+
+所有 trap 立即恢复，**无数据丢失，无用户可见影响**，仅消耗维护者额外 ~15 min。Cleanup 任务本身成功完成（仓库现 local=2 / remote=3 refs + `delete_branch_on_merge=true` 已启用）。
+
+## §2 Timeline
+
+| Time (UTC) | Event | By |
+|------|-------|-----|
+| 2026-05-18 04:50 | 开始 bulk cleanup，执行 pre-flight 4-check 全过 | maintainer + Claude |
+| 2026-05-18 04:52 | 执行 `git branch --merged develop \| grep -v ... \| xargs git branch -d` | Claude |
+| 2026-05-18 04:53 | 输出含 `error: branch '+' not found` 与 `Deleted branch main (was 587cd12).` | observation |
+| 2026-05-18 04:53 | 立即诊断：bare worktree 用 `+ main` prefix；原 regex `^\s*\*?\s*` 未匹配 `+` | Claude |
+| 2026-05-18 04:54 | 恢复：`git branch main origin/main` | Claude |
+| 2026-05-18 04:56 | 转向 remote 删除；首次 `git push origin --delete` 5 个分支（按 audit 列表） | Claude |
+| 2026-05-18 04:57 | RPC 错误 + `git fetch --prune` 显示 5 个确实已删；但 `git branch -r` 仍 35 个 | observation |
+| 2026-05-18 04:58 | 诊断：audit 把 "remote 与 local 同名" 等同 "remote 已同步删除"，实际两者独立 | Claude |
+| 2026-05-18 04:59 | 第二轮 `xargs git push origin --delete` 删 33 个，全成功 | Claude |
+| 2026-05-18 05:05 | 尝试 `gh api -X PATCH /repos/...`，Git Bash 报 `invalid API endpoint: "C:/Program Files/Git/repos/..."` | observation |
+| 2026-05-18 05:06 | 诊断：MSYS 路径改写；去 leading slash 重试成功 | Claude |
+| 2026-05-18 05:08 | `delete_branch_on_merge: true` 设置生效 | confirmation |
+| 2026-05-18 05:10 | Final verify：local=2 / remote=3 refs / setting=true，incident closed | maintainer |
+
+## §3 Root Cause
+
+- **Immediate cause** (Trap #1)：filter regex `^\s*\*?\s*(main|develop)$` 字符类只覆盖 `*` 不含 `+`；bare repo + worktree 模式下 `main` 被 `.bare/` 占用，`git branch` 输出 `+ main`，未被过滤，泄漏到 `xargs`。
+- **Immediate cause** (Trap #2)：`git branch -d` 是本地操作，不触发 `push --delete`；原 audit 报告语义不严谨（"sync with" 同时含 "都存在" 与 "保持同步" 两义）。
+- **Immediate cause** (Trap #3)：MSYS2 path translation 把任何以 `/` 开头的 CLI 参数视为 POSIX 路径并改写为 Windows 路径，影响 `gh api`、`docker exec` 等 endpoint-style 参数。
+- **Contributing factors**：
+  - 项目内 `mp-git-cleanup` skill 是 single-PR oriented，无 bulk 场景；3 traps 均未在 SKILL.md 出现
+  - Explore agent audit prompt 没要求显式区分 "local-only / remote-only / both" 三态
+  - Windows Git Bash 是 maintainer 默认 shell，无 Linux/macOS 对比基线
+- **Root cause**：marketplace project assets 未捕获 bare-repo + worktree + Windows 三件套特有 gotcha；首次大规模 bulk cleanup 暴露所有 3 个。
+
+## §4 Impact
+
+- **Users affected**: 0（marketplace 用户 / plugin 消费者 / GitHub PR reviewers 均无感知）
+- **Plugins affected**: 0
+- **Data affected**: local `main` ref 暂失 ~30s，从 `origin/main` 恢复完整。Commit 历史、PR 历史、tag、GitHub Release 全部不变
+- **Public statement made**: no（severity P3 不触发）
+
+## §5 Remediation
+
+### §5.1 Immediate (during incident)
+
+- `git branch main origin/main` 恢复本地 main ref
+- 第二轮 `git push origin --delete <33 branches>` 完成 remote cleanup
+- `gh api -X PATCH repos/...`（去 leading slash）启用 `delete_branch_on_merge=true`
+
+### §5.2 Short-term (within 1 week — THIS PR)
+
+- F1 ：`.claude/skills/mp-git-cleanup/SKILL.md` 加 Bulk Cleanup Mode 章节，3 traps inline
+- F2: 本 POSTMORTEM 文档（首份 `docs/postmortem/*`）
+- F3: `.claude/skills/mp-git-merge-gate/SKILL.md` 加 Windows gh api 1 行警告
+- F4: `docs/guide/[GUIDE]_Contributing.md` "Bare Repo + Worktree" 段加 prefix 说明
+- F5: `docs/runbook/[RUNBOOK]_Release_Operations.md` §2.6 + §3.7 cleanup callouts；v1.3.1 → v1.3.2
+- F6: 新建 `scripts/safe-bulk-cleanup.ps1` — pre-flight + dry-run-default 安全脚本
+
+### §5.3 Long-term (process / tooling changes)
+
+- 已启用 GitHub repo `delete_branch_on_merge=true`（cycle 自动 cover Trap #2 99% 场景）
+- 未来 explore agent prompt 设计：要求 "local-only / remote-only / both" 三态显式区分
+- 维护者 onboarding checklist 可加 "Windows Git Bash gotcha 阅读" 一项（暂不强制）
+
+## §6 Action Items
+
+| # | Action | Owner | Due | Status |
+|---|--------|-------|-----|--------|
+| 1 | F1: mp-git-cleanup Bulk Mode + 3 traps | ranzuozhou | 2026-05-18 | in this PR |
+| 2 | F2: 本 POSTMORTEM | ranzuozhou | 2026-05-18 | done (this file) |
+| 3 | F3: merge-gate Windows warning | ranzuozhou | 2026-05-18 | in this PR |
+| 4 | F4: Contributing GUIDE prefix note | ranzuozhou | 2026-05-18 | in this PR |
+| 5 | F5: RUNBOOK cleanup callouts (v1.3.2) | ranzuozhou | 2026-05-18 | in this PR |
+| 6 | F6: safe-bulk-cleanup.ps1 | ranzuozhou | 2026-05-18 | in this PR |
+| 7 | 评估是否给 mp-doc-validate 加 POSTMORTEM 字段校验 | ranzuozhou | open | future |
+
+## §7 Lessons Learned
+
+- **Bare repo + worktree 模式有非 stock-git 行为**：`+` 前缀仅在该模式下出现，常规 git 教程不覆盖。任何过滤 `git branch` 输出的脚本都需用 `[ *+]` 字符类。
+- **"Sync" 这个词在 cleanup 上下文要警惕**：local 与 remote 是两条独立 ref 命名空间，删 local 不动 remote。任何 audit / 计划文档涉及 "同步" 必须显式标注操作方向。
+- **Windows Git Bash 的 MSYS 路径改写**是 `gh api` / `docker exec` / 任何带 leading-slash CLI 参数都会触发的隐藏陷阱；遇到 `invalid endpoint: "C:/Program Files/..."` 类错误立即检查参数前缀。
+- **Cleanup 类任务看似 trivial 但失败模式非显然**：dry-run + 候选列表先 `cat` 验证（不要直接管道给 `xargs`）是低成本高收益的护栏，应成为默认习惯。
+- **首次 exercise POSTMORTEM 模板的价值**：模板 8 段对 P3 事件略重，但跑通一次让团队对未来 P0-P1 事件文档化有清晰路径；本文档同时验证了 `docs/postmortem/` 目录从 placeholder 转 active 的可行性。
+
+## §8 References
+
+- Issue: 无（内部 incident，未开 GitHub Issue）
+- PR (fix): 本 PR（待合后填）
+- Related RUNBOOK: [`../runbook/[RUNBOOK]_Release_Operations.md`](../runbook/[RUNBOOK]_Release_Operations.md) §2.6 / §3.7
+- Related SKILL: [`../../.claude/skills/mp-git-cleanup/SKILL.md`](../../.claude/skills/mp-git-cleanup/SKILL.md) §Bulk Cleanup Mode
+- Related Script: [`../../scripts/safe-bulk-cleanup.ps1`](../../scripts/safe-bulk-cleanup.ps1)
+- Memory (session-local lesson): `~/.claude/projects/.../memory/feedback_branch_cleanup_traps.md`

--- a/docs/runbook/[RUNBOOK]_Release_Operations.md
+++ b/docs/runbook/[RUNBOOK]_Release_Operations.md
@@ -6,7 +6,7 @@ owner: marketplace-maintainers
 created: 2026-03-17
 updated: 2026-05-18
 state: active
-version: v1.3.1
+version: v1.3.2
 last-verified: 2026-05-18
 domain: release
 tags:
@@ -19,7 +19,9 @@ related:
   - ../spec/[SPEC]_Marketplace_Json_Schema.md
   - ../rule/[STANDARD]_AI_Engineering_Execution_HITL_Prompt.md
   - ../adr/[ADR]_Develop_PreBump_Adoption.md
+  - ../postmortem/[POSTMORTEM]_2026-05-18_Bulk_Cleanup_Trap_Analysis.md
 revision: |
+  2026-05-18 — v1.3.2: §2.6 + §3.7 加 cleanup callout box — single-PR cleanup 现可依赖 GitHub `delete_branch_on_merge=true` (v4.6.2+ 启用)，bulk 场景指向 `.claude/skills/mp-git-cleanup/SKILL.md` §Bulk Cleanup Mode + `scripts/safe-bulk-cleanup.ps1`；frontmatter related[] 加 POSTMORTEM_2026-05-18 引用。procedural commands 不变。Non-trigger archive（patch revision，无 Framework §2.3.1 触发条件）。
   2026-05-18 — v1.3.1: scrub external project references per `[STANDARD]_AI_Engineering_Execution_HITL_Prompt` §0.3 independence principle (frontmatter summary + this revision line + §3.7 "Why" callout reworded)；technical procedure 不变。
   2026-05-18 — v1.3: 引入 develop post-release 预 bump 机制 (per `[ADR]_Develop_PreBump_Adoption`)。新增 §3.7 "Post-release develop 预 bump"（sync-main-to-develop 完成后即在 develop 上执行 `bump-version.ps1 -From X.Y.Z -To X.Y.(Z+1)` 一个 commit；pure patch 风格无 `-dev` 后缀；只 bump 顶层 VERSION，不连带 plugin.json）；§4.5 加 hotfix 与预 bump 冲突 TODO 标记（暂不预设处理，待首次 hotfix 事件再补 §4.6）；§6 发布前检查清单加 1 项后置 "release 完成后 72h 内 develop 已预 bump"。Configures `verify-develop-prebumped.yml` warn-only CI 作为遗忘提醒兜底（72h 宽限）。Non-trigger archive（minor bump，无 Framework §2.3.1 触发条件）。
   2026-05-18 — v1.2: **CLAUDE.md 自动化 sync**（closes #110）。§3.2.1 post-bump verification 第 2 步 wording 从 "CLAUDE.md plugin line manual：script 不 cover" 改为 "script 已 cover (v2 起)；保留 grep verify 作为 last-line defense"；§6 发布前检查清单第 3 项 wording 同步更新；cross-reference 加 PR #115 (Issue #110 closure) + 内含 marketplace.json `[^}]*` regex bug 顺手修复（描述含 `}` 时 silent SKIP，已修为 `[\s\S]*?` 非贪婪）。bump-version.ps1 现 cover 全 5 Quintangle sites，三层防御 (script 覆盖 + CI guard + RUNBOOK MANDATORY) 完工。Non-trigger archive（minor bump，无 Framework §2.3.1 触发条件）。
@@ -146,6 +148,16 @@ git branch -d feature/12-add-release-skill
 # 可选：远程分支通常在 PR 合并后由 GitHub 自动删除
 git push origin --delete feature/12-add-release-skill
 ```
+
+> [!note]
+> **v4.6.2+ 起 GitHub repo 已启用 `delete_branch_on_merge=true`**：single-PR merge 后 head 分支自动删，**通常无需**手动 `git push origin --delete`。仅以下场景需手动 bulk 处理：
+>
+> 1. 清历史遗留孤儿（GitHub 设置启用前累积的）
+> 2. 一次清多个分支（>5）
+>
+> Bulk 场景用 [`.claude/skills/mp-git-cleanup/SKILL.md`](../../.claude/skills/mp-git-cleanup/SKILL.md) §Bulk Cleanup Mode（含 3 traps 警告）或 [`scripts/safe-bulk-cleanup.ps1`](../../scripts/safe-bulk-cleanup.ps1)（pre-flight + dry-run-default）。
+>
+> 2026-05-18 incident 实证 (P3) 见 [`../postmortem/[POSTMORTEM]_2026-05-18_Bulk_Cleanup_Trap_Analysis.md`](../postmortem/[POSTMORTEM]_2026-05-18_Bulk_Cleanup_Trap_Analysis.md)。
 
 ## 3. 发布阶段
 
@@ -337,6 +349,9 @@ git push origin develop
 
 预 bump 完成后 `verify-develop-prebumped.yml` workflow 在 next push 时验证 `develop VERSION > main VERSION` 成立，输出 OK 注释。
 
+> [!note]
+> Post-release sync-PR + pre-bump-PR 合并完成后，对应 maintain/* head 分支由 GitHub `delete_branch_on_merge=true` 自动删（v4.6.2+）；本地 worktree 用 `/mp-git-cleanup` skill single-PR 流程清理。若历史累积多个 PR 未清理，走 §Bulk Cleanup Mode（见 [`.claude/skills/mp-git-cleanup/SKILL.md`](../../.claude/skills/mp-git-cleanup/SKILL.md) + [`scripts/safe-bulk-cleanup.ps1`](../../scripts/safe-bulk-cleanup.ps1)）。
+
 ## 4. Hotfix 流程
 
 用于修复已发布版本的紧急问题。
@@ -438,6 +453,7 @@ git push origin --delete v1.1.0
 
 ## 7. 版本历史
 
+- **v1.3.2**（2026-05-18）：§2.6 + §3.7 加 cleanup callout box —— single-PR cleanup 现可依赖 GitHub `delete_branch_on_merge=true`（v4.6.2+ 启用），bulk 场景指向 `.claude/skills/mp-git-cleanup/SKILL.md` §Bulk Cleanup Mode + `scripts/safe-bulk-cleanup.ps1`。Frontmatter related[] 加 POSTMORTEM_2026-05-18 引用。Procedural commands 完全不变。Non-trigger archive（patch revision）。
 - **v1.3.1**（2026-05-18）：scrub 外部项目引用 per `[STANDARD]_AI_Engineering_Execution_HITL_Prompt` §0.3 独立性原则；frontmatter summary + revision + §3.7 "为什么需要" callout reworded；技术流程 (§3.7 / §4.5 / §6 / `verify-develop-prebumped.yml`) 完全不变。Non-trigger archive。
 - **v1.3**（2026-05-18）：引入 develop post-release 预 bump 机制（per `[ADR]_Develop_PreBump_Adoption`）。新增 §3.7 "Post-release develop 预 bump" — sync-main-to-develop 完成后在 develop 上执行 `bump-version.ps1 -From X.Y.Z -To X.Y.(Z+1)` 一个 commit；pure patch 风格无 `-dev` 后缀；只 bump 顶层 VERSION，不连带 plugin.json。§4.5 加 hotfix 与预 bump 冲突 TODO 标记（暂不预设处理，待首次 hotfix 事件再补 §4.6）。§6 发布后检查清单加 1 项 "72h 内完成预 bump"。配套 `.github/workflows/verify-develop-prebumped.yml` warn-only CI 在 72h 宽限外提醒。Frontmatter v1.2 → v1.3 + revision block + 加 `[ADR]_Develop_PreBump_Adoption` 到 related。Non-trigger archive（minor bump，无 Framework §2.3.1 触发条件）。
 - **v1.2**（2026-05-18）：**CLAUDE.md 自动化 sync**（closes #110）。§3.2.1 第 2 步 + §6 第 3 项 wording 从「manual / script 不 cover」更新为「script 已 cover (v2 起 plugin scope 含 CLAUDE.md scoped-regex 分支)；grep 保留作 last-line defense」。配套 PR #115 同时修了 `scripts/bump-version.ps1` 中 marketplace.json `[^}]*` regex bug（描述含 `}` 时 silent SKIP）。bump-version.ps1 现真正 cover 全 5 Quintangle sites，三层防御 (script 覆盖 + CI guard + RUNBOOK MANDATORY) 完工。Frontmatter v1.1 → v1.2 + revision block。Non-trigger archive。

--- a/scripts/safe-bulk-cleanup.ps1
+++ b/scripts/safe-bulk-cleanup.ps1
@@ -1,0 +1,235 @@
+<#
+.SYNOPSIS
+    Safe bulk cleanup of merged Git branches (local + optional remote)
+
+.DESCRIPTION
+    Wraps the 4-check pre-flight + 3-trap-aware deletion logic per
+    `.claude/skills/mp-git-cleanup/SKILL.md` §Bulk Cleanup Mode.
+
+    Pre-flight checks (all must pass; otherwise STOP):
+      1. No unmerged branches vs integration branch (default: develop)
+      2. No open PRs (gh)
+      3. Only protected worktrees exist (.bare + integration worktree)
+      4. Candidate list dry-printed for human inspection
+
+    Then deletes candidates with safety:
+      - Uses `git for-each-ref refs/heads/` (no prefix; Trap #1-safe)
+      - Multi-layer protected-branch refusal (main, develop, current HEAD)
+      - DRY-RUN by default; -Apply flag required to execute
+      - Remote cleanup opt-in via -IncludeRemote (Trap #2 explicit)
+
+    Born from 2026-05-18 incident — see
+    docs/postmortem/[POSTMORTEM]_2026-05-18_Bulk_Cleanup_Trap_Analysis.md
+
+.PARAMETER Apply
+    Execute deletions. Without this flag, runs in DRY-RUN mode (default).
+
+.PARAMETER IncludeRemote
+    Also delete remote orphan branches (branches in origin/* not in local
+    after local cleanup, excluding protected). Only meaningful with -Apply.
+
+.PARAMETER IntegrationBranch
+    Base branch used for merge check. Defaults to "develop".
+
+.PARAMETER Repo
+    GitHub repo for `gh pr list` check. Defaults to
+    "MJ-AgentLab/mj-agentlab-marketplace".
+
+.EXAMPLE
+    pwsh ./scripts/safe-bulk-cleanup.ps1
+    # Dry-run; print candidates and predicted commands; modify nothing.
+
+.EXAMPLE
+    pwsh ./scripts/safe-bulk-cleanup.ps1 -Apply
+    # Delete local candidates after pre-flight passes.
+
+.EXAMPLE
+    pwsh ./scripts/safe-bulk-cleanup.ps1 -Apply -IncludeRemote
+    # Delete local + remote orphans.
+#>
+
+param(
+    [switch]$Apply,
+    [switch]$IncludeRemote,
+    [string]$IntegrationBranch = "develop",
+    [string]$Repo = "MJ-AgentLab/mj-agentlab-marketplace"
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$ProjectRoot = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+Set-Location $ProjectRoot
+
+$ProtectedPattern = '^(main|develop)$'
+
+function Write-Section($title) {
+    Write-Host ""
+    Write-Host ("=" * 60) -ForegroundColor DarkGray
+    Write-Host $title -ForegroundColor Cyan
+    Write-Host ("=" * 60) -ForegroundColor DarkGray
+}
+
+function Stop-WithError($msg) {
+    Write-Host ""
+    Write-Host "STOP: $msg" -ForegroundColor Red
+    exit 1
+}
+
+Write-Section "safe-bulk-cleanup.ps1"
+Write-Host "Mode:               $(if ($Apply) { 'EXECUTE' } else { 'DRY-RUN (default; use -Apply to execute)' })" -ForegroundColor $(if ($Apply) { 'Yellow' } else { 'Green' })
+Write-Host "IncludeRemote:      $IncludeRemote"
+Write-Host "IntegrationBranch:  $IntegrationBranch"
+Write-Host "Repo:               $Repo"
+Write-Host "ProjectRoot:        $ProjectRoot"
+
+# ============ Pre-flight Check 1: No unmerged branches ============
+Write-Section "Pre-flight 1: unmerged branches vs $IntegrationBranch"
+
+$unmerged = & git branch --no-merged $IntegrationBranch 2>&1
+if ($LASTEXITCODE -ne 0) {
+    Stop-WithError "git branch --no-merged failed: $unmerged"
+}
+$unmergedList = @($unmerged | Where-Object { $_ -match '\S' })
+if ($unmergedList.Count -gt 0) {
+    Write-Host "Unmerged branches found:" -ForegroundColor Red
+    $unmergedList | ForEach-Object { Write-Host "  $_" }
+    Stop-WithError "Pre-flight 1 FAILED: $($unmergedList.Count) unmerged branch(es). Resolve before bulk cleanup."
+}
+Write-Host "OK: no unmerged branches" -ForegroundColor Green
+
+# ============ Pre-flight Check 2: No open PRs ============
+Write-Section "Pre-flight 2: open PRs on $Repo"
+
+$openPRs = & gh pr list -R $Repo --state open --json number,headRefName 2>&1
+if ($LASTEXITCODE -ne 0) {
+    Stop-WithError "gh pr list failed: $openPRs"
+}
+$openPRsParsed = @($openPRs | ConvertFrom-Json)
+if ($openPRsParsed.Count -gt 0) {
+    Write-Host "Open PRs found:" -ForegroundColor Red
+    $openPRsParsed | ForEach-Object { Write-Host "  PR #$($_.number): $($_.headRefName)" }
+    Stop-WithError "Pre-flight 2 FAILED: $($openPRsParsed.Count) open PR(s). Wait for merge/close or skip cleanup."
+}
+Write-Host "OK: 0 open PRs" -ForegroundColor Green
+
+# ============ Pre-flight Check 3: Worktrees ============
+Write-Section "Pre-flight 3: active worktrees"
+
+$worktreesRaw = & git worktree list 2>&1
+$worktrees = @($worktreesRaw | Where-Object { $_ -match '\S' })
+Write-Host "Current worktrees ($($worktrees.Count)):"
+$worktrees | ForEach-Object { Write-Host "  $_" }
+
+$extraWorktrees = @($worktrees | Where-Object {
+    $_ -notmatch '\.bare\s+\(bare\)$' -and
+    $_ -notmatch "[\\/]$IntegrationBranch\s+[0-9a-f]+\s+\[$IntegrationBranch\]$"
+})
+if ($extraWorktrees.Count -gt 0) {
+    Write-Host "Extra worktrees beyond .bare + $IntegrationBranch detected:" -ForegroundColor Yellow
+    $extraWorktrees | ForEach-Object { Write-Host "  $_" -ForegroundColor Yellow }
+    Stop-WithError "Pre-flight 3 FAILED: clean up extra worktrees via /mp-git-cleanup single-PR mode first, then re-run."
+}
+Write-Host "OK: only .bare + $IntegrationBranch worktrees" -ForegroundColor Green
+
+# ============ Build candidate list (Trap #1-safe via for-each-ref) ============
+Write-Section "Pre-flight 4: candidate list (Trap #1-safe via for-each-ref)"
+
+$allLocal = @(& git for-each-ref refs/heads/ --format='%(refname:short)')
+$candidates = @($allLocal | Where-Object { $_ -notmatch $ProtectedPattern })
+
+Write-Host "Local branches total:      $($allLocal.Count)"
+Write-Host "Protected (skip):          $($allLocal.Count - $candidates.Count) [$(($allLocal | Where-Object { $_ -match $ProtectedPattern }) -join ', ')]"
+Write-Host "Candidates for deletion:   $($candidates.Count)"
+
+if ($candidates.Count -eq 0) {
+    Write-Host ""
+    Write-Host "No local cleanup candidates. Repo is clean." -ForegroundColor Green
+    if (-not $IncludeRemote) {
+        exit 0
+    }
+}
+
+Write-Host ""
+Write-Host "Candidate branches:" -ForegroundColor Yellow
+$candidates | ForEach-Object { Write-Host "  $_" }
+
+# Defense-in-depth: re-check no protected name leaked into candidates
+$leaked = @($candidates | Where-Object { $_ -match $ProtectedPattern })
+if ($leaked.Count -gt 0) {
+    Stop-WithError "Internal sanity check FAILED: protected branch leaked into candidates: $($leaked -join ', '). Aborting."
+}
+
+# ============ Local deletion ============
+Write-Section "Local deletion"
+
+if (-not $Apply) {
+    Write-Host "[DRY-RUN] would execute:" -ForegroundColor DarkGray
+    $candidates | ForEach-Object { Write-Host "  git branch -d $_" -ForegroundColor DarkGray }
+} else {
+    foreach ($branch in $candidates) {
+        $result = & git branch -d $branch 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "  Deleted: $branch" -ForegroundColor Green
+        } else {
+            Write-Host "  FAILED: $branch  ($result)" -ForegroundColor Red
+        }
+    }
+}
+
+# ============ Remote deletion (opt-in) ============
+if ($IncludeRemote) {
+    Write-Section "Remote deletion (-IncludeRemote)"
+
+    & git fetch --prune origin 2>&1 | Out-Null
+
+    $allRemote = @(& git for-each-ref refs/remotes/origin/ --format='%(refname:short)')
+    $remoteCandidates = @(
+        $allRemote |
+        Where-Object { $_ -ne 'origin/HEAD' } |
+        ForEach-Object { $_ -replace '^origin/', '' } |
+        Where-Object { $_ -notmatch $ProtectedPattern }
+    )
+
+    Write-Host "Remote branches total:     $($allRemote.Count)"
+    Write-Host "Remote candidates:         $($remoteCandidates.Count)"
+
+    if ($remoteCandidates.Count -eq 0) {
+        Write-Host "No remote orphans." -ForegroundColor Green
+    } else {
+        Write-Host ""
+        Write-Host "Remote candidates:" -ForegroundColor Yellow
+        $remoteCandidates | ForEach-Object { Write-Host "  origin/$_" }
+
+        $leakedRemote = @($remoteCandidates | Where-Object { $_ -match $ProtectedPattern })
+        if ($leakedRemote.Count -gt 0) {
+            Stop-WithError "Internal sanity check FAILED: protected branch leaked into remote candidates: $($leakedRemote -join ', '). Aborting."
+        }
+
+        if (-not $Apply) {
+            Write-Host ""
+            Write-Host "[DRY-RUN] would execute:" -ForegroundColor DarkGray
+            Write-Host "  git push origin --delete $($remoteCandidates -join ' ')" -ForegroundColor DarkGray
+        } else {
+            Write-Host ""
+            Write-Host "Deleting $($remoteCandidates.Count) remote branches..." -ForegroundColor Cyan
+            $deleteArgs = @('push', 'origin', '--delete') + $remoteCandidates
+            & git @deleteArgs
+        }
+    }
+}
+
+# ============ Summary ============
+Write-Section "Summary"
+
+if (-not $Apply) {
+    Write-Host "DRY-RUN complete. Re-run with -Apply to execute." -ForegroundColor Yellow
+    Write-Host "  pwsh ./scripts/safe-bulk-cleanup.ps1 -Apply $(if ($IncludeRemote) { '-IncludeRemote' })"
+} else {
+    Write-Host "Cleanup applied. Verify with:" -ForegroundColor Cyan
+    Write-Host "  git branch                          # expect only $IntegrationBranch + main"
+    Write-Host "  git branch -r                       # expect only origin/$IntegrationBranch + origin/main + HEAD pointer"
+    Write-Host "  git worktree list                   # expect .bare + $IntegrationBranch only"
+}
+
+Write-Host ""


### PR DESCRIPTION
## 变更摘要

把 2026-05-18 bulk cleanup incident 暴露的 3 个 trap 内化为永久项目资产，避免下次 bulk cleanup 重蹈覆辙。

完整事故根因 + remediation 见同 PR 的 [`docs/postmortem/[POSTMORTEM]_2026-05-18_Bulk_Cleanup_Trap_Analysis.md`](../blob/maintain/cleanup-traps-hardening/docs/postmortem/%5BPOSTMORTEM%5D_2026-05-18_Bulk_Cleanup_Trap_Analysis.md)。Severity P3，已恢复 / 0 数据丢失。

**3 traps**:
1. `git branch` 输出 `+ <name>` 前缀（bare repo + worktree 模式下，被另一 worktree 占用的分支）被常规 filter regex 漏过 → `main` 被误删（即刻 `git branch main origin/main` 恢复）
2. Local `git branch -d` ≠ remote 删除 → audit 用语 "sync with" 歧义，遗漏 33 个远端孤儿
3. Windows Git Bash 把 `gh api /repos/...` 改写成 `C:/Program Files/Git/repos/...`，端点失败

## 影响评估

7 文件 / 4 commits / +542 / -9 lines：

| File | 改动 | Trap |
|------|------|------|
| `docs/postmortem/[POSTMORTEM]_2026-05-18_Bulk_Cleanup_Trap_Analysis.md` | NEW (124 行) — 项目首份 POSTMORTEM | 全部 3 |
| `scripts/safe-bulk-cleanup.ps1` | NEW (235 行) — pre-flight + dry-run-default | 全部 3 |
| `.claude/skills/mp-git-cleanup/SKILL.md` | +131 行 — §Bulk Cleanup Mode 新章节 | 全部 3 |
| `.claude/skills/mp-git-merge-gate/SKILL.md` | +3 行 — Windows callout | #3 |
| `docs/guide/[GUIDE]_Contributing.md` | v1.0 → v1.1 — prefix 子段 + frontmatter | #1 |
| `docs/runbook/[RUNBOOK]_Release_Operations.md` | v1.3.1 → v1.3.2 — §2.6 + §3.7 callouts | #2 |
| `docs/INDEX.md` | v4.6.1 → v4.6.2 — postmortem 行 + 3 row 描述更新 | (索引同步) |
| `CHANGELOG.md` | `[Unreleased]` Added×3 + Changed×3 entries | — |

**无 plugin / VERSION / CI workflow 改动**。learn-kit 仍 1.2.0；VERSION 仍 4.6.2；release.yml / ci.yml / verify-develop-prebumped.yml 不变。

## 审核要点

- POSTMORTEM 文档是 Framework v1.5 §2.4 `docs/postmortem/` placeholder 的首次填充 —— exercise 模板 8 段完整骨架
- mp-git-cleanup §Bulk Cleanup Mode 是 single-PR mode (Steps 1-7) 的 opt-in 补充；single-PR 行为不变（backward compat）
- safe-bulk-cleanup.ps1 dry-run-default + 多层 protected-branch refusal 是 belt-and-suspenders 设计 —— 即使脚本自身有 bug，仍需用户显式 `-Apply` 才动手
- 4 commits 按 logical scope 拆分（POSTMORTEM / docs+skills / RUNBOOK / script），任一可独立 review

## 自检结果

- [x] 配置文件语法正确（PowerShell `[scriptblock]::Create` 解析通过；所有 markdown frontmatter 8 字段齐全）
- [x] CI/CD 流水线不受影响（不动 workflow 文件）
- [x] 无硬编码敏感信息
- [x] Commit message 符合规范（4/4 PATTERN OK：`docs(marketplace)` × 2 + `docs(docs-runbook)` × 1 + `infra(scripts)` × 1）
- [x] CHANGELOG.md `[Unreleased]` 区块已更新（详细 Added × 3 + Changed × 3 entries）

## 本地验证

```bash
$ bash scripts/validate-commits.sh origin/develop..HEAD
[OK] 4 commit(s) validated in range 'origin/develop..HEAD'; 0 failures

$ # 外部项目引用扫描 (per STANDARD §0.3 independence principle)
$ for f in <7 governance files>; do grep -c -iE 'mj-system|MJ-System' "$f"; done
0 0 0 0 0 0 0   # all 0 hits

$ # PowerShell syntax
$ pwsh -Command "[scriptblock]::Create((Get-Content -Raw scripts/safe-bulk-cleanup.ps1)) | Out-Null"
PS syntax OK

$ # safe-bulk-cleanup.ps1 dry-run validation
$ pwsh ./scripts/safe-bulk-cleanup.ps1
Pre-flight 1: OK no unmerged branches  ← validates logic
Pre-flight 2: 0 open PRs (after @() fix) ← validates logic
Pre-flight 3: STOP (extra worktree: maintain-cleanup-traps)  ← correct conservative refusal
```

## 风险评估

- **Zero functional risk**：纯文档 + 新增 read-only 脚本 + skill 扩展；backward compat 100%
- **safe-bulk-cleanup.ps1 自身的失败风险**：dry-run-default + 多层 refusal + StrictMode；最坏情况 = 用户看到错误信息脚本退出，不会破坏状态
- **Reversibility**：full revert 任一文件可独立回滚

## 关联

- POSTMORTEM (本 PR 内): [`docs/postmortem/[POSTMORTEM]_2026-05-18_Bulk_Cleanup_Trap_Analysis.md`](../blob/maintain/cleanup-traps-hardening/docs/postmortem/%5BPOSTMORTEM%5D_2026-05-18_Bulk_Cleanup_Trap_Analysis.md)
- 上游 cleanup PR cycle: #119 → #124（pre-bump 机制端到端验证，引发本 incident 的 cleanup 任务）
- STANDARD §0.3 独立性原则 (所有新增 governance 文档 0 处 mj-system 引用)
