### PR TITLE
fix(scripts): safe-bulk-cleanup.ps1 -IncludeRemote drops bare origin HEAD ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`scripts/safe-bulk-cleanup.ps1`** `-IncludeRemote` 路径 P3 解析 bug — `git for-each-ref refs/remotes/origin/` 把 HEAD symbolic ref 返回为裸 `origin`（不是 `origin/HEAD`），原 filter `Where-Object { $_ -ne 'origin/HEAD' }` 漏过，导致 dry-run 错误显示 `git push origin --delete origin` 为候选命令。修复：改用 `Where-Object { $_ -match '^origin/.+' }` 强制 `origin/` 前缀 + 至少 1 字符后缀。Bug 被脚本本身的 dry-run-default + candidate 列表打印 + 多层 protected-branch refusal 拦截，无实际删除风险。Smoke test in clean develop env: OLD filter → 1 bogus `origin` candidate; NEW filter → 0 candidates。
+
 ### Added
 
 - **`docs/postmortem/[POSTMORTEM]_2026-05-18_Bulk_Cleanup_Trap_Analysis.md`** — 项目首份 POSTMORTEM 文档（填补 Framework v1.5 §2.4 `docs/postmortem/` placeholder）。记录 2026-05-18 bulk branch cleanup 触发的 3 个 trap：(1) `git branch` `+` 前缀漏过滤导致 local `main` 误删；(2) local `git branch -d` 不动 remote，audit 用语 "sync with" 歧义误导；(3) Windows Git Bash 把 `gh api /repos/...` 改写成 Windows 路径。Severity P3（恢复，0 数据丢失）。

--- a/scripts/safe-bulk-cleanup.ps1
+++ b/scripts/safe-bulk-cleanup.ps1
@@ -184,9 +184,12 @@ if ($IncludeRemote) {
     & git fetch --prune origin 2>&1 | Out-Null
 
     $allRemote = @(& git for-each-ref refs/remotes/origin/ --format='%(refname:short)')
+    # Note: `git for-each-ref refs/remotes/origin/` returns the HEAD symbolic ref
+    # as bare `origin` (not `origin/HEAD`) — must filter with `^origin/.+` to drop it,
+    # else `origin` leaks through and the script would suggest `git push origin --delete origin`.
     $remoteCandidates = @(
         $allRemote |
-        Where-Object { $_ -ne 'origin/HEAD' } |
+        Where-Object { $_ -match '^origin/.+' } |
         ForEach-Object { $_ -replace '^origin/', '' } |
         Where-Object { $_ -notmatch $ProtectedPattern }
     )


### PR DESCRIPTION
## 变更摘要

Follow-up bugfix to PR #125. The `-IncludeRemote` path of `safe-bulk-cleanup.ps1` had a P3 filter bug: `git for-each-ref refs/remotes/origin/` returns the HEAD symbolic ref as bare `origin` (not `origin/HEAD`), which the original filter `Where-Object { $_ -ne 'origin/HEAD' }` failed to drop, producing a bogus dry-run line `git push origin --delete origin`.

**Severity P3** — bug was intercepted by dry-run-default + candidate list printing + multi-layer protected-branch refusal; **0 data risk**.

## 影响评估

- 1 line in `scripts/safe-bulk-cleanup.ps1` (filter logic) + 3-line inline comment explaining the gotcha
- CHANGELOG.md `[Unreleased]` Fixed entry added
- No skill / RUNBOOK / POSTMORTEM / GUIDE changes

## 审核要点

- Fix is structural: `Where-Object { $_ -match '^origin/.+' }` requires `origin/` prefix + ≥1 char — drops bare `origin` while keeping legitimate `origin/<branch>` entries (then `$ProtectedPattern` filters out `main`/`develop` as before)
- Smoke test (inline parse from develop worktree): OLD filter → 1 bogus `origin`; NEW filter → 0 candidates
- Bug origin documented inline as a code comment to prevent reintroduction

## 自检结果

- [x] 配置文件语法正确（PowerShell 解析通过）
- [x] CI/CD 流水线不受影响
- [x] 无硬编码敏感信息
- [x] Commit message 符合规范（`fix(scripts)` ✓ validate-commits.sh `[OK] 1 commit`）
- [x] CHANGELOG.md `[Unreleased]` Fixed entry added

## 本地验证

```bash
$ pwsh -Command '
  $raw = @(git for-each-ref refs/remotes/origin/ --format="%(refname:short)")
  $old = @($raw | Where-Object { $_ -ne "origin/HEAD" } | ForEach-Object { $_ -replace "^origin/", "" } | Where-Object { $_ -notmatch "^(main|develop)$" })
  $new = @($raw | Where-Object { $_ -match "^origin/.+" } | ForEach-Object { $_ -replace "^origin/", "" } | Where-Object { $_ -notmatch "^(main|develop)$" })
  Write-Host "OLD candidates: $($old.Count) [$($old -join ", ")]"
  Write-Host "NEW candidates: $($new.Count)"
'
OLD candidates: 1 [origin]
NEW candidates: 0
```
