### PR TITLE
infra(marketplace): narrow Remove-Item deny and drop enabledPlugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,15 +10,11 @@
     ],
     "deny": [
       "Bash(rm -rf*)",
-      "Bash(Remove-Item*)",
+      "Bash(Remove-Item)",
       "Bash(del *)",
       "Read(./.env)",
       "Edit(./.env)",
       "Write(./.env)"
     ]
-  },
-  "enabledPlugins": {
-    "mp-dev@my-marketplace": true,
-    "mp-git@my-marketplace": true
   }
 }


### PR DESCRIPTION
## 变更摘要

调整 `.claude/settings.json` 中的 Claude Code 工作区 harness 配置，做两处本地化清理：

1. **收窄 `Bash(Remove-Item*)` deny 规则 → `Bash(Remove-Item)`**：原通配符模式把所有带参数的 `Remove-Item` 调用全部拦截，过于宽泛；改为只拦截裸命令，允许显式带参用法走单次确认提示。
2. **删除 `enabledPlugins` 块**（`mp-dev@my-marketplace`、`mp-git@my-marketplace`）：这两个条目引用了一个不在本仓库内的外部 marketplace（`my-marketplace`），仅对个人本地 Claude Code 安装有意义，留在仓库共享 settings 里会误导其他贡献者尝试加载不存在的 plugin。

属于纯本地 harness 微调，无 plugin/skill 行为变化、无市场元数据变化、无 CI/release 流程变化。

## 影响评估

| 维度 | 影响 |
|---|---|
| 仓库内的 plugin (`learn-kit`) | 无影响 |
| `.claude-plugin/marketplace.json` / `VERSION` | 未触及 |
| `.github/workflows/*.yml` (CI/release) | 未触及 |
| `scripts/*.{ps1,sh}` | 未触及 |
| 贡献者工作区 | `Remove-Item -Path foo` 之类的命令不再被静态拦截，仍走单次权限提示；克隆 repo 后不再自动尝试加载外部 `my-marketplace` 插件 |

## 审核要点

- JSON 语法是否仍合法（已本地核对：保留 `permissions` 对象 + `deny`/`ask`/`allow` 三段；末尾缺少 trailing newline，与上一次 develop 顶部状态一致，但仍可考虑后续顺手补回）。
- 是否应当在 commit 中同时保留 `Bash(Remove-Item*)`+`Bash(Remove-Item)` 两条以兼顾"严格拦截全形态"与"显式裸命令"——本 PR 选择只保留 `Bash(Remove-Item)` 以贴近用户实际填写；若 reviewer 倾向更严格策略，可在合并前补回通配版本。
- `enabledPlugins` 历史上是怎么进入共享 settings 的？是否需要在 `.claude/settings.local.json`（gitignore 范围内）里给个人开发者重新启用提示？本 PR 不涉及该补充。

## 自检结果

- [x] 配置文件语法正确（`.claude/settings.json` 仍是合法 JSON，`permissions.deny` / `ask` / `allow` 三段保留）
- [x] CI/CD 流水线不受影响（未触及 `.github/workflows/*`、`scripts/*`、`marketplace.json`、`VERSION`）
- [x] 无硬编码敏感信息（无 secret/key/password/token 引入）
- [x] Commit message 符合规范（`infra(marketplace): …`；本地 `scripts/validate-commits.sh HEAD~1..HEAD` 已通过 PATTERN 校验）
- [x] CHANGELOG.md `[Unreleased]` 未更新 — 纯内部 harness 配置调整，对市场用户不可见，按模板末项豁免

## Related

- Commit: 23a6fdc `infra(marketplace): narrow Remove-Item deny and drop local enabledPlugins`
- 起点：`origin/develop` @ 39f45ef
