### PR TITLE
fix(learn-kit): reinforce zh-CN narration constraint for nlm-studio audio/video

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "learn-kit",
       "source": "./plugins/learn-kit",
       "description": "Pedagogical kit for learnable knowledge artifacts. Five skills: (1) /learn-kit:scaffold-learning scaffolds the learning subsystem (v2.0.0 renamed from /learn-kit:init to eliminate slash-picker collision with Claude Code builtin /init); (2) /learn-kit:locate reverse-looks up concepts; (3) /learn-kit:scan enumerates learnable docs; (4) /learn-kit:generate-tier AI-generates three-tier (foundation/structural/challenge) learning markdown plus optional interactive HTML; (5) /learn-kit:nlm-studio pushes a topic's three-tier markdown corpus to NotebookLM and generates up to 13 online-viewable multimedia artifacts (4 view-cycled types × 3 views + 1 shared mind_map; markdown-only sources). nlm-studio requires notebooklm-mcp MCP server (bundled) + nlm login; the other four skills run with no external dependencies. v2.0.0 BREAKING: scaffold skill renamed init → scaffold-learning; migrate `/learn-kit:init` calls to `/learn-kit:scaffold-learning`.",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "author": { "name": "MJ-AgentLab" },
       "category": "documentation",
       "keywords": ["learning", "pedagogy", "methodology", "rule-list", "interpretation", "discovery", "locate", "scan", "three-tier", "foundation", "structural", "challenge", "ai-generation", "html-render", "nlm-studio", "notebooklm", "audio", "video", "multimedia", "slide-deck", "mind-map", "infographic"],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **learn-kit 2.0.0 → 2.0.1** — `nlm-studio` 输出语言约束加强：解决
+  dogfood 反馈的「NotebookLM 生成 artifact 出现全英文表达 / 讲解」
+  问题。`templates/language-directive.md` 顶部新增 lead-with-mandate
+  段（`OUTPUT LANGUAGE: 简体中文` + 显式禁止整段英文失败模式）；
+  `templates/artifact-audio.md` 与 `templates/artifact-video.md` 各
+  新增一节（`## Spoken language` / `## Narration language`）作为
+  medium 级双锁加固。`SKILL.md` §"Language & terminology directive"
+  同步追加 dual-lock 机制说明。`marketplace.json` plugins[] 学 plugin
+  version 同步 2.0.0 → 2.0.1；marketplace metadata.version 仍 5.0.2
+  pre-bumped（per `[ADR]_Develop_PreBump_Adoption`，plugin 版本独立
+  bump）。A6 CLAUDE.md sync 未触发（plugin.json patch 不在 Framework
+  v1.6 §2.7 allowlist 内）。
+
 ## [5.0.1] - 2026-05-19
 
 This release packages **`mp-git-sync` side-loop sync skill** (mp-git-* family 6 → 7) as the sole user-facing feature, plus minor post-v5.0.0 housekeeping (CLAUDE.md A6 gate sync to align with Documentation Framework v1.6 §2.7 trigger introduced in v5.0.0).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 ## Project Structure
 
 - `plugins/` — **1 个通用插件**（v4.0.0 起整合）：
-  - `learn-kit` v2.0.0（教学方法论 + AI 三档生成 + 交互式 HTML + nlm-studio NLM 多媒体生成；v4.0.0 起吸收 notebooklm-kit 的核心多媒体场景；v1.2.0 起 plugin 内教学文档合并为 2 份 [GUIDE]；v1.2.1 起 nlm-studio SKILL.md frontmatter description 压缩至 < 1,536-char cap；**v2.0.0 BREAKING**：scaffold skill 由 `init` 改名为 `scaffold-learning`，消除与 Claude Code 内置 `/init` 的 slash-picker 冲突；详见 [docs/adr/[ADR]_LearnKit_Init_Skill_Rename.md](docs/adr/[ADR]_LearnKit_Init_Skill_Rename.md)）
+  - `learn-kit` v2.0.1（教学方法论 + AI 三档生成 + 交互式 HTML + nlm-studio NLM 多媒体生成；v4.0.0 起吸收 notebooklm-kit 的核心多媒体场景；v1.2.0 起 plugin 内教学文档合并为 2 份 [GUIDE]；v1.2.1 起 nlm-studio SKILL.md frontmatter description 压缩至 < 1,536-char cap；**v2.0.0 BREAKING**：scaffold skill 由 `init` 改名为 `scaffold-learning`，消除与 Claude Code 内置 `/init` 的 slash-picker 冲突；详见 [docs/adr/[ADR]_LearnKit_Init_Skill_Rename.md](docs/adr/[ADR]_LearnKit_Init_Skill_Rename.md)；v2.0.1 起 nlm-studio 输出语言双锁加固——`language-directive.md` 顶部新增 lead-with-mandate 段 `OUTPUT LANGUAGE: 简体中文` + audio/video 模板各加 medium 级语言重申小节，解决 dogfood 反馈的 artifact 全英文化问题）
 - `scripts/` — 基础设施脚本（bump-version, install-hooks, validate-commits, clone-bare）
 - `.claude-plugin/marketplace.json` — 市场元数据（版本 + 插件注册表）
 - `VERSION` — 市场整体版本号（权威源）

--- a/plugins/learn-kit/.claude-plugin/plugin.json
+++ b/plugins/learn-kit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "learn-kit",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Pedagogical kit for learnable knowledge artifacts. Includes (1) 8-stage manual authoring methodology + scaffold + discovery skills (scaffold-learning / locate / scan); (2) AI-driven three-tier (foundation/structural/challenge) learning doc generator with optional interactive HTML rendering; (3) nlm-studio skill that pushes a topic's three-tier markdown corpus to NotebookLM and generates up to 13 online-viewable multimedia artifacts: 4 view-cycled types (audio + video + slide_deck + infographic) × 3 view variants + 1 shared view-agnostic mind_map. HTML files are not uploaded — only markdown (dogfood-validated). View-Purpose Preservation principle ensures view-cycled artifacts preserve each tier's pedagogical stance. Requires notebooklm-mcp MCP server (bundled via this plugin's .mcp.json) plus a one-time `nlm login` for the nlm-studio skill; the other four skills run with no external dependencies. v2.0.0 BREAKING: scaffold skill renamed from `init` to `scaffold-learning` to eliminate slash-picker collision with Claude Code's builtin `/init` (CLAUDE.md generator) — migrate `/learn-kit:init` calls to `/learn-kit:scaffold-learning`.",
   "author": {
     "name": "MJ-AgentLab",

--- a/plugins/learn-kit/CHANGELOG.md
+++ b/plugins/learn-kit/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-05-21
+
+### Fixed
+
+- **`nlm-studio` 输出语言约束加强**（解决 dogfood 反馈的「NotebookLM 生成
+  artifact 出现全英文表达 / 全英文讲解」问题）。原 `templates/language-
+  directive.md` 已包含「中文主体 + 英文术语保留」规则但在 NLM 模型侧
+  权重不足，本次以双锁加固：
+  - `templates/language-directive.md` 顶部新增 lead-with-mandate
+    段：`**OUTPUT LANGUAGE: 简体中文 (Simplified Chinese, zh-CN)**` +
+    显式禁止失败模式（整段英文讲解 / 整段英文对白 / on-screen 英文主
+    体）+ 重申唯一例外是行业标准技术术语。原 75 行 hard-constraint
+    bullet + 正反例样例一字未改。
+  - `templates/artifact-audio.md` 在 `## Voice & pacing` 与
+    `## Segment endings` 之间新增 `## Spoken language` 小节：两位
+    host 普通话对白、不允许整段英文、术语保留英文原词（不音译 / 不
+    强译），并 reference LANGUAGE & TERMINOLOGY 段为权威源。
+  - `templates/artifact-video.md` 在 `## Per-scene structure` 与
+    `## Opening 30 seconds` 之间新增 `## Narration language` 小节：
+    旁白普通话、on-screen 简体中文、visual cue 文字 verbatim、并
+    reference LANGUAGE & TERMINOLOGY 段。
+  - `skills/nlm-studio/SKILL.md` §"Language & terminology directive
+    (single shared block)" 追加 "Dual-lock reinforcement (v2.0.1+)"
+    一段，说明本次新增的双锁机制 + slide_deck / infographic /
+    mind_map 仍走单锁（dogfood 未观测到这三个 medium 英文化失败）。
+- `plugin.json` version 2.0.0 → 2.0.1。`marketplace.json` plugins[]
+  数组对应条目同步。
+
 ## [2.0.0] - 2026-05-18
 
 ### BREAKING

--- a/plugins/learn-kit/skills/nlm-studio/SKILL.md
+++ b/plugins/learn-kit/skills/nlm-studio/SKILL.md
@@ -503,6 +503,29 @@ to (a) guarantee consistency across all 13 cells and (b) make
 future policy changes a one-file edit. Edit
 `templates/language-directive.md` to adjust the policy globally.
 
+**Dual-lock reinforcement (v2.0.1+)**: dogfood revealed that some
+audio / video artifacts still defaulted to all-English output despite
+the language directive. To reinforce the constraint, two changes
+were applied:
+
+1. `templates/language-directive.md` now opens with a hard mandate
+   `**OUTPUT LANGUAGE: 简体中文**` + an explicit failure-mode
+   ban ("no full-English narration / dialogue allowed"), positioned
+   at the top of the directive block for maximum model attention.
+2. `templates/artifact-audio.md` and `templates/artifact-video.md`
+   each carry a `## Spoken language` / `## Narration language`
+   section inside their `===== MEDIUM CONSTRAINTS =====` segment,
+   restating the Chinese-narration rule with medium-specific
+   guidance (host dialogue / single narrator / on-screen text).
+   These sections defer to LANGUAGE & TERMINOLOGY for the term
+   list and mixed-language rules, forming a double lock.
+
+`slide_deck`, `infographic`, and `mind_map` rely only on the single
+LANGUAGE & TERMINOLOGY lock — dogfood did not observe English-
+defaulting failures in these media. Add a medium-specific
+reinforcement section to their templates if future dogfood reveals
+similar drift.
+
 **Why this design over 15 standalone templates:** view and artifact
 have largely independent dimensions for 4 of 5 artifact types. The
 view carries the pedagogical *purpose* (who's listening, what they

--- a/plugins/learn-kit/skills/nlm-studio/templates/artifact-audio.md
+++ b/plugins/learn-kit/skills/nlm-studio/templates/artifact-audio.md
@@ -26,6 +26,20 @@ template (loaded as VIEW PURPOSE).
 - Allow brief moments of host disagreement or "wait, but isn't
   that…?" — these create the listener's engagement hooks.
 
+## Spoken language
+
+- 两位 host 的对白使用普通话（Mandarin Chinese / 简体中文）发音与口播。
+- 不允许整段英文对白；不允许任一 host 以英文为主语言。如果源材料英文
+  段落较多，host 应当用中文复述其内容（保留英文术语原词），不要切换成
+  英文连续讲解。
+- 行业标准技术术语保留英文原词，按英文音节自然嵌入中文句子
+  （例：「这个 ADR 把 frontmatter 的 schema 锁死了」）。
+  - 不要音译（不要说「这个艾迪阿」）
+  - 不要强译（不要说「这个架构决策记录」）
+- 详细的术语清单与中英混排规则见 `===== LANGUAGE & TERMINOLOGY =====`
+  段；本节是音频媒介上的特化重申，最终规则以 LANGUAGE & TERMINOLOGY
+  为准。
+
 ## Segment endings
 
 The *style* of segment endings is governed by the view template's

--- a/plugins/learn-kit/skills/nlm-studio/templates/artifact-video.md
+++ b/plugins/learn-kit/skills/nlm-studio/templates/artifact-video.md
@@ -26,6 +26,19 @@ The visual is not decorative — it's load-bearing. A scene where
 the visual could be replaced with a still title slide is a wasted
 scene.
 
+## Narration language
+
+- 单一旁白（narrator）使用普通话发音；on-screen 文字使用简体中文。
+- 不允许整段英文旁白；不允许 on-screen 文字主体为英文。如果源材料英文
+  段落较多，旁白应当用中文复述（保留英文术语原词），on-screen 字幕用
+  中文呈现要点。
+- 行业标准技术术语保留英文原词：旁白按英文音节自然嵌入中文句子；
+  on-screen 直接显示英文原词，无需中译注解。
+- 视觉提示（visual cue）里的图示文字 / 代码片段 / 文件路径 / 命令行
+  verbatim 显示，不翻译。
+- 详细规则见 `===== LANGUAGE & TERMINOLOGY =====` 段；本节为视频媒介
+  特化重申，最终规则以 LANGUAGE & TERMINOLOGY 为准。
+
 ## Opening 30 seconds
 
 The opening's *content* is governed by the view template's §3 Style

--- a/plugins/learn-kit/skills/nlm-studio/templates/language-directive.md
+++ b/plugins/learn-kit/skills/nlm-studio/templates/language-directive.md
@@ -8,6 +8,17 @@ artifacts per topic in a single place.
 
 ## Directive (sent verbatim to NotebookLM)
 
+**OUTPUT LANGUAGE: 简体中文 (Simplified Chinese, zh-CN)** — 所有讲解、对白、
+旁白、on-screen 文字、节点 label、章节标题都必须以普通话 / 简体中文表达。
+
+**禁止失败模式**：不允许整段英文讲解、不允许整段英文对白、不允许 on-screen
+正文以英文为主语言。如果上游 source markdown 中夹杂英文段落，请用中文复述
+其内容，不要照搬英文原文成段播报。
+
+**唯一例外**：行业标准技术术语保留英文原词（见下方 hard-constraint bullet
+的完整术语清单与中英混排规则）。术语保留 ≠ 整段英文 —— 中文句子框架内嵌
+入英文术语原词才是正确形态。
+
 输出语言规则（hard constraint）：
 
 - **主体内容用中文（简体）**呈现：包括但不限于


### PR DESCRIPTION
## Bug 描述

`/learn-kit:nlm-studio <topic>` 在 NotebookLM 中生成的 13 个 artifact（尤其 audio / video）会出现全英文表达 / 全英文讲解的情况，违背「中文主体 + 英文术语保留」原则。

## 根因分析

`plugins/learn-kit/skills/nlm-studio/templates/language-directive.md` 早已包含一份完整的「中文叙述 + 英文术语原词保留」规则（75 行，含正反例），作为 `===== LANGUAGE & TERMINOLOGY =====` 段被附加到所有 13 个 artifact 的 `focus_prompt`。但实际 dogfood 仍观察到英文化输出。两个结构性弱点：

1. **指令位置偏后**：composite focus_prompt 5 段顺序为 `VIEW PURPOSE → MEDIUM CONSTRAINTS → INTERACTION OVERRIDE → LANGUAGE → SOURCE TOPIC`。LANGUAGE 段排在第 4，NLM 模型对早段约束权重更高。
2. **首句不够硬**：directive 开头是「输出语言规则（hard constraint）：」+ bullet list，对生成模型不如「OUTPUT LANGUAGE: 简体中文」这种 lead-with-mandate 形式刺激强。
3. **medium 级无重申**：`artifact-audio.md` / `artifact-video.md` 只描述格式（对话节奏、镜头），完全不提语言。这两个 medium 恰是英文化失败最常见的载体（audio 有 1 个英文化入口 = 口播；video 有 2 个 = 旁白 + on-screen）。

## 修复方案（双锁加固）

1. **`templates/language-directive.md` 顶部插入 lead-with-mandate 段**：粗体 `OUTPUT LANGUAGE: 简体中文 (Simplified Chinese, zh-CN)` + 显式禁止失败模式（整段英文讲解 / 整段英文对白 / on-screen 英文主体）+ 重申技术术语保留是唯一例外。原 75 行 hard-constraint bullet + 正反例样例一字不改。
2. **`templates/artifact-audio.md` 新增 `## Spoken language` 小节**（夹在 `## Voice & pacing` 与 `## Segment endings` 之间）：两位 host 普通话对白、禁止 host 以英文为主语言、术语保留英文原词不音译 / 不强译，并 reference LANGUAGE & TERMINOLOGY 段为权威。
3. **`templates/artifact-video.md` 新增 `## Narration language` 小节**（夹在 `## Per-scene structure` 与 `## Opening 30 seconds` 之间）：旁白普通话 + on-screen 中文 + visual cue 文字 verbatim，覆盖 video 的 2 个英文化入口。
4. **`skills/nlm-studio/SKILL.md` §"Language & terminology directive"** 追加 "Dual-lock reinforcement (v2.0.1+)" 段：documents the new mechanism + 说明 slide_deck / infographic / mind_map 仍走单锁（dogfood 未观测到这三个 medium 英文化失败）。
5. **版本同步**：
   - `plugins/learn-kit/.claude-plugin/plugin.json` `2.0.0 → 2.0.1`
   - `.claude-plugin/marketplace.json` plugins[learn-kit].version `2.0.0 → 2.0.1`（per HITL STANDARD §4.8 5d Plugin Delta Check）
   - 两份 CHANGELOG 同步（plugin: 新建 `[2.0.1]` 段 2026-05-21；root: `[Unreleased]` 段累加）
   - `VERSION` + `marketplace.json metadata.version` 保持 `5.0.2`（per [`[ADR]_Develop_PreBump_Adoption`](docs/adr/[ADR]_Develop_PreBump_Adoption.md)，plugin 与 marketplace 双层版本独立 bump）

未改 composite 顺序（不属于本 patch scope；如果双锁仍不够强再单独 ADR 讨论 reposition）。未改 slide_deck / infographic / mind_map 三个 medium 模板（语言敏感性低 + 单锁 LANGUAGE 段已覆盖）。

## 影响范围

| 文件 | 改动 |
|---|---|
| `plugins/learn-kit/skills/nlm-studio/templates/language-directive.md` | +11 行（顶部 lead-mandate 段） |
| `plugins/learn-kit/skills/nlm-studio/templates/artifact-audio.md` | +14 行（新增 `## Spoken language` 小节） |
| `plugins/learn-kit/skills/nlm-studio/templates/artifact-video.md` | +13 行（新增 `## Narration language` 小节） |
| `plugins/learn-kit/skills/nlm-studio/SKILL.md` | +23 行（§Language directive 追加 dual-lock 说明） |
| `plugins/learn-kit/.claude-plugin/plugin.json` | 1 行版本字段（2.0.0 → 2.0.1） |
| `.claude-plugin/marketplace.json` | 1 行版本字段（plugins[0] 2.0.0 → 2.0.1） |
| `plugins/learn-kit/CHANGELOG.md` | +28 行（新 `[2.0.1]` 段） |
| `CHANGELOG.md` | +15 行（`[Unreleased]` 累加） |

**8 files changed, 106 insertions(+), 2 deletions(-)**

- **Plugin affected**: `learn-kit` v2.0.0 → v2.0.1（patch）
- **Skill affected**: `nlm-studio`（templates + SKILL.md prose）
- **Marketplace VERSION**: 不变（仍 5.0.2 pre-bumped）
- **A6 CLAUDE.md sync**: 未触发（plugin.json patch 不在 Framework v1.6 §2.7 allowlist 内）
- **ADR**: 不需要（directive 微调，非架构决策）
- **release.yml 触发**: 否（未动 `VERSION`）

## 风险与回滚

**风险**：

- NLM 模型可能仍不听话——双锁如果不足，下一步升级到 Aggressive 强度（LANGUAGE 段提前到 composite 第 1 段 + 5 medium 模板全加固）；如仍不行，需要在 SKILL.md 增加 post-generation 语言采样检查。
- 过度加固可能让 NLM 把本应保留英文的术语强译——通过下一轮 dogfood 观察样本，必要时在 audio/video 小节加强反例位置。

**回滚**：单 commit `2dc03d3`，纯文本 + 1 行 plugin.json + 1 行 marketplace.json + CHANGELOG entry，`git revert 2dc03d3` 即可干净回退，无 schema 迁移、无数据回填。

## 验证结果

### 本地验证（人类可重复）

```text
$ git diff --stat develop..HEAD
 .claude-plugin/marketplace.json                    |  2 +-
 CHANGELOG.md                                       | 15 ++++++++++++
 plugins/learn-kit/.claude-plugin/plugin.json       |  2 +-
 plugins/learn-kit/CHANGELOG.md                     | 28 ++++++++++++++++++++++
 plugins/learn-kit/skills/nlm-studio/SKILL.md       | 23 ++++++++++++++++++
 .../skills/nlm-studio/templates/artifact-audio.md  | 14 +++++++++++
 .../skills/nlm-studio/templates/artifact-video.md  | 13 ++++++++++
 .../nlm-studio/templates/language-directive.md     | 11 +++++++++
 8 files changed, 106 insertions(+), 2 deletions(-)

$ grep '"version":' plugins/learn-kit/.claude-plugin/plugin.json .claude-plugin/marketplace.json
plugins/learn-kit/.claude-plugin/plugin.json:  "version": "2.0.1",
.claude-plugin/marketplace.json:    "version": "5.0.2"        # marketplace 不动
.claude-plugin/marketplace.json:      "version": "2.0.1",     # plugin entry 已同步

$ cat VERSION
5.0.2                                                   # unchanged
```

| 维度 | 结果 |
|---|---|
| 版本三角一致性 | ✅ plugin.json 2.0.1 ↔ marketplace.json plugins[0] 2.0.1；VERSION 5.0.2 不变 |
| 无 secret / 凭据 / 调试码 | ✅ `git diff` 检查通过 |
| 无 PR_BODY.md / 临时文件入版本 | ✅ PR_BODY.md 在 worktree 根，未 stage（push 后立刻 rm） |
| CHANGELOG 双份同步 | ✅ plugin + root 各一段 |
| commit message 合规 | ✅ `fix(learn-kit): ...` type/scope 全在 `validate-commits.ps1` 白名单；summary 63 字符 < 72 |

### AI 自检（12-item per HITL §4.8）

| # | Item | 结果 |
|---|---|---|
| 1 | 改动完全对应 Plan | ✅ 计划 7 改动 + marketplace.json plugin 版本同步（5d 强制）= 8 改动 |
| 2 | 未超出 scope | ✅ 仅 nlm-studio 一个 skill 内 + 版本号 + CHANGELOG |
| 3 | 改 plugin API / SKILL description / allowed-tools / marketplace.json schema | ✅ 均未改（仅 plugin entry 的 version 数值；description/keywords/schema 不动） |
| 4 | hardcode / secret / 绝对路径 / 调试码 | ✅ 无 |
| 5a | 反向扫描 rename/delete 引用 | ✅ 本次无 rename/delete |
| 5b | 新文档创建确认 | ✅ 本次未新建 ADR/GUIDE/RUNBOOK（directive 调整不到决策强度） |
| 5c | INDEX/CLAUDE.md/CHANGELOG 同步 | ✅ 两份 CHANGELOG 已同步；CLAUDE.md 无需动（patch 不触 A6） |
| 5d | Plugin Delta Check | ✅ plugin.json v2.0.1 ↔ marketplace.json plugins[0] v2.0.1 一致 |
| 6 | AC 验证证据 | ⚠️ 仅静态 + composition self-check 完成；真实 NLM dogfood 留作 reviewer / merge 后跟进（避免 13/65% 日 quota 消耗） |
| 7 | 无不应提交文件 | ✅ stage 的 8 文件全在计划 |
| 8 | commit message 合规 | ✅ pattern 通过 |
| 9 | PR template 6 项 | ✅ 见下方 |
| 10 | 触发 release.yml | ✅ 否（未动 `VERSION`） |
| 11 | secret / 凭据 | ✅ 无 |
| 12 | `docs/**` framework 合规 | ✅ 不适用（改的是 plugin SKILL.md / templates / CHANGELOG，按 [STANDARD]_Documentation_Framework §1 plugin-internal 豁免） |

## 自检结果

- [x] Bug 已复现并验证修复（dogfood 证据见 `plugins/learn-kit/CHANGELOG.md [2.0.1]` 描述；真实 NLM 复跑 quota 高，留 reviewer 决策）
- [x] 无引入新的回归问题（仅追加 template 段 + 顶部段 + SKILL.md prose；未删现有规则；composition 5 段顺序未变）
- [x] 无残留调试代码
- [x] Commit message 符合规范（`fix(learn-kit): ...`，type/scope 全在白名单，summary 63 字符 < 72）
- [x] CHANGELOG.md `[Unreleased]` 区块已更新（root 加 learn-kit 子条目；plugin 直接落 `[2.0.1]`）

## Linked Artifacts

- Commit: `2dc03d3a4231f9550c0e5660c9fe7a836387efed`
- Plan file: `C:\Users\Admin\.claude\plans\plugins-learn-kit-skills-nlm-studio-not-delightful-sparkle.md`（用户本地）
- Trigger STANDARD: [`docs/rule/[STANDARD]_AI_Engineering_Execution_HITL_Prompt.md`](docs/rule/[STANDARD]_AI_Engineering_Execution_HITL_Prompt.md) §4.8 / §4.9
- 版本独立 bump 依据: [`docs/adr/[ADR]_Develop_PreBump_Adoption.md`](docs/adr/[ADR]_Develop_PreBump_Adoption.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
