### PR TITLE
fix(infra): scope MCP allow rule to project's notebooklm-mcp server

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
       "Read",
       "Write",
       "WebFetch",
-      "mcp__*"
+      "mcp__plugin_learn-kit_notebooklm-mcp__*"
     ],
     "deny": [
       "Bash(rm -rf*)",


### PR DESCRIPTION
## Bug 描述

`/doctor` 报告 `.claude/settings.json › permissions.allow` 中的 `"mcp__*"` 规则被判为非法并**静默跳过**——其"自动批准本项目 MCP 工具"的意图实际未生效。

## 根因分析

Claude Code 的 **allow** 规则不接受裸通配工具名：allow pattern 必须命名其放宽的 server 作用域。合法形式为 `mcp__<server>` / `mcp__<server>__<tool>` / `mcp__<server>__*`（通配符只允许出现在 `mcp__<server>__` 字面前缀之后的 tool 位置）。`mcp__*` 缺少 server 前缀，故被跳过。（deny / ask 规则不受此限，所以现有 `deny` 条目无需改动。）

## 修复方案

将 `"mcp__*"` 替换为本仓库唯一自带 MCP server 的作用域通配：`"mcp__plugin_learn-kit_notebooklm-mcp__*"`（来自 `plugins/learn-kit/.mcp.json` 的 `notebooklm-mcp`）。

- 保留原"自动批准"意图，作用域收敛到仓库真正依赖的 MCP server。
- 其余个人/全局 MCP server（context7 / mermaidchart / pg-aiguide / Gmail 等）非本仓依赖，继续走正常授权提示——它们本就不该出现在这份 git-tracked 的共享配置里。

单行改动，`deny` 块原样保留，JSON 有效性已校验。

## 影响范围

- 仅 `.claude/settings.json`（仓库 agent 工具配置）。
- 不涉及任何 plugin / skill 行为；不触及 plugin.json / marketplace.json / VERSION / `docs/` 结构 → **A6 CLAUDE.md sync gate 不触发**。

## 自检结果
- [x] Bug 已复现并验证修复（`/doctor` 报错条目；改后 JSON 有效，规则作用域合法）
- [x] 无引入新的回归问题（`deny` 块不变；其他 allow 条目不变）
- [x] 无残留调试代码
- [x] Commit message 符合规范（`fix(infra)`；`scripts/validate-commits.sh` 0 failures）
- [ ] CHANGELOG.md `[Unreleased]` 区块已更新 — **N/A**：此为仓库内部 `.claude/settings.json` 工具配置修复，非面向 consumer 的 marketplace / plugin 变更，不进发布日志

🤖 Generated with [Claude Code](https://claude.com/claude-code)
