### PR TITLE
infra(infra): remove ineffective Write(./.env) deny rule

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,8 +13,7 @@
       "Bash(Remove-Item)",
       "Bash(del *)",
       "Read(./.env)",
-      "Edit(./.env)",
-      "Write(./.env)"
+      "Edit(./.env)"
     ]
   }
 }


### PR DESCRIPTION
## 变更摘要
`.claude/settings.json` 的 `permissions.deny` 里同时存在 `Edit(./.env)` 和 `Write(./.env)` 两条规则。Claude Code 的权限引擎（含 sandbox filesystem 层，参 `sandbox.filesystem.allowWrite`/`denyWrite` schema 说明 "Merged with paths from Edit(...) allow/deny permission rules"）把所有会修改文件的工具（Write / Edit / NotebookEdit）统一到 `Edit(path)` 规则命名空间下做路径级匹配；单独写 `Write(path)` 的路径级规则永远不会被实际匹配到。

`Edit(./.env)` 已经能拦住 Write / Edit / NotebookEdit 对 `.env` 的操作，`Write(./.env)` 是死规则——不仅不生效，还会误导后来维护者以为 Write 和 Edit 需要分别配置路径级规则。本 PR 删掉这条无效行，只保留真正生效的 `Edit(./.env)`（以及 `Read(./.env)`）。

## 影响评估
- 仅影响本仓库 `.claude/settings.json` 的本地开发工具权限配置，不涉及任何 plugin / marketplace.json / CI workflow / 发布行为。
- `.env` 的实际保护级别不变（`Edit(./.env)` 一直在生效，本次只是去掉不生效的冗余行）。

## 审核要点
- 确认 `Edit(./.env)` 单条规则确实覆盖 Write / Edit / NotebookEdit 对 `.env` 的读写拦截。
- 确认仓库内无其他路径级 `Write(...)` 规则残留（已 grep 确认，仅此一处）。

## 自检结果
- [x] 配置文件语法正确（JSON 结构完整，`jq`/Read 校验通过）
- [x] CI/CD 流水线不受影响（未改 `.github/workflows/**`）
- [x] 无硬编码敏感信息（密钥、IP、密码）
- [x] Commit message 符合规范（`infra(infra): ...`，仅 infra 类型）
- [x] CHANGELOG.md `[Unreleased]` 区块已更新（如本次维护引入了用户可见的变更；纯内部 CI/脚本调整可豁免）—— 本次改动为纯内部 `.claude/settings.json` 权限配置修正，不影响任何 plugin / marketplace 对外行为，按豁免条款不更新 CHANGELOG

## 说明
根据 `CONTRIBUTING.md` §发布流程，Gitee 同步是 merge 到 main 触发 release 后自动执行的，不需要针对本次 develop 分支 PR 手动双推。
