### PR TITLE
infra(release): draft-first evaluator-gated release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,63 +1,88 @@
 name: Release
 
+# Draft-first, evaluator-gated release (plan §3 Task 3, §2.4). Fires on a VERSION change landing on
+# main, or by manual dispatch. ALL business logic — phase transitions, digest normalisation,
+# canonical selection, the draft-first state machine — lives in scripts/resolve-release-state.mjs
+# and scripts/run-release.mjs (both unit-tested); this file only sets up the toolchain and hands
+# the orchestrator a token. It creates an empty draft, uploads + digest/bytes/install-verifies the
+# two assets, re-queries adjacent to publish, and only then publishes: a failure fails closed at the
+# draft stage, leaving an unpublished draft to inspect. A published asset is never patched in place.
+#
+# Supply-chain: third-party Actions are pinned to a full commit SHA (tag in the trailing comment),
+# an elevation over the rest of the repo that this publish-to-production workflow warrants. uv is the
+# exact pinned 0.11.21 via the versioned installer (house style; see codex-canary.yml).
+
 on:
   push:
     branches: [main]
     paths: ['VERSION']
+  workflow_dispatch:
+    inputs:
+      release_sha:
+        description: 'Full 40-char commit SHA to release (must be an ancestor of main). Defaults to the checked-out main tip.'
+        required: false
+        type: string
+
+# One release at a time; never cancel a release in flight (a cancelled publish is far worse than a
+# queued one).
+concurrency:
+  group: release-main
+  cancel-in-progress: false
+
+permissions:
+  contents: write
 
 jobs:
   release:
     name: Create Release
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          fetch-depth: 0
+          fetch-depth: 0 # full history: the orchestrator reads VERSION/CHANGELOG at the canonical SHA and checks ancestry
 
-      - name: Extract version
-        id: version
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22'
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv 0.11.21 (pinned)
         run: |
-          VERSION=$(cat VERSION | tr -d '[:space:]')
-          if ! echo "$VERSION" | grep -qP '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "ERROR: Invalid version format '$VERSION'"
-            exit 1
+          set -euo pipefail
+          curl -LsSf https://astral.sh/uv/0.11.21/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Verify uv version
+        run: |
+          set -euo pipefail
+          UV_VERSION="$(uv --version | awk '{print $2}')"
+          if [ "$UV_VERSION" != "0.11.21" ]; then
+            echo "::error::expected uv 0.11.21, found $UV_VERSION"; exit 1
           fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Check if tag exists
-        id: check_tag
-        run: |
-          if git tag -l "v${{ steps.version.outputs.version }}" | grep -q .; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-            echo "Tag v${{ steps.version.outputs.version }} already exists, skipping release"
-          else
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Create and push tag
-        if: steps.check_tag.outputs.exists == 'false'
-        run: |
-          VERSION="v${{ steps.version.outputs.version }}"
-          git tag "$VERSION"
-          git push origin "$VERSION"
-
-      - name: Extract release notes from CHANGELOG
-        if: steps.check_tag.outputs.exists == 'false'
-        id: notes
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          NOTES=$(awk "/^## \\[$VERSION\\]/{found=1; next} /^## \\[/{if(found) exit} found{print}" CHANGELOG.md)
-          echo "$NOTES" > /tmp/release-notes.md
-          echo "--- Release Notes ---"
-          cat /tmp/release-notes.md
-
-      - name: Create GitHub Release
-        if: steps.check_tag.outputs.exists == 'false'
+      - name: Resolve release SHA
+        id: rel
+        # A dispatch input is attacker-adjacent text: validate it here and carry it only via env.
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_SHA: ${{ inputs.release_sha }}
+          DEFAULT_SHA: ${{ github.sha }}
         run: |
-          gh release create "v${{ steps.version.outputs.version }}" \
-            --title "v${{ steps.version.outputs.version }}" \
-            --notes-file /tmp/release-notes.md
+          set -euo pipefail
+          SHA="${INPUT_SHA:-$DEFAULT_SHA}"
+          # Whole-string bash regex, not a per-line grep: a multiline value with one 40-hex line
+          # would pass `grep -qE '^...$'` and then inject extra key=value pairs into GITHUB_OUTPUT.
+          if [[ ! "$SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::release_sha must be a single 40-char lowercase hex SHA (got '${SHA}')"; exit 1
+          fi
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Run draft-first release
+        env:
+          RELEASE_SHA: ${{ steps.rel.outputs.sha }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          RUNNER_TEMP: ${{ runner.temp }}
+        run: node scripts/run-release.mjs

--- a/docs/runbook/[RUNBOOK]_Release_Operations.md
+++ b/docs/runbook/[RUNBOOK]_Release_Operations.md
@@ -6,8 +6,8 @@ owner: marketplace-maintainers
 created: 2026-03-17
 updated: 2026-07-20
 state: active
-version: v1.4
-last-verified: 2026-05-18
+version: v1.5
+last-verified: 2026-07-20
 domain: release
 tags:
   - release
@@ -21,6 +21,7 @@ related:
   - ../adr/[ADR]_Develop_PreBump_Adoption.md
   - ../postmortem/[POSTMORTEM]_2026-05-18_Bulk_Cleanup_Trap_Analysis.md
 revision: |
+  2026-07-20 — v1.5: §3.6「合并 → 自动发布」从旧 tag-first 简单流程重写为 v7.0.0 起的 **draft-first 加固流程**（tri-state 探测 → identity/integrity evaluator → uv 构建 wheel + `.sha256` → create-draft/upload/verify/publish 状态机 → 只读 immutability + warn-only public-URL 校验；已发布资产绝不就地修补）。对应 `.github/workflows/release.yml` 重写 + 新增 `scripts/run-release.mjs` / `scripts/release-verify-install.mjs`。Procedural 发布顺序（§3.1–§3.5 / §3.7）不变。Non-trigger archive（minor bump，无 Framework §2.3.1 触发条件）。
   2026-07-20 — v1.4: v7.0.0 Codex dual-native sync。§3.2 MANDATORY callout 补 `bump-version.ps1` 事务性说明（anchored value-level edit + two-phase write + 任一站点失败全量回滚）；§3.2.1 post-bump verification 的 CLAUDE.md grep 加 `diagram-kit`，quintangle 站点检查扩展加 Codex `.codex-plugin/plugin.json` parity + `node scripts/validate-dual-host.mjs`；§6 发布前检查清单加 dual-host consistency 项（`.codex-plugin` 共享字段与 `.claude-plugin` parity）。Non-trigger archive（minor bump，无 Framework §2.3.1 触发条件）。
   2026-05-18 — v1.3.2: §2.6 + §3.7 加 cleanup callout box — single-PR cleanup 现可依赖 GitHub `delete_branch_on_merge=true` (v4.6.2+ 启用)，bulk 场景指向 `.claude/skills/mp-git-cleanup/SKILL.md` §Bulk Cleanup Mode + `scripts/safe-bulk-cleanup.ps1`；frontmatter related[] 加 POSTMORTEM_2026-05-18 引用。procedural commands 不变。Non-trigger archive（patch revision，无 Framework §2.3.1 触发条件）。
   2026-05-18 — v1.3.1: scrub external project references per `[STANDARD]_AI_Engineering_Execution_HITL_Prompt` §0.3 independence principle (frontmatter summary + this revision line + §3.7 "Why" callout reworded)；technical procedure 不变。
@@ -303,24 +304,28 @@ Release PR 模板审核要点：
 - [ ] 无残留调试代码
 - [ ] 无未关闭的阻塞性 Issue
 
-### 3.6 合并 → 自动发布
+### 3.6 合并 → 自动发布（v7.0.0 起：draft-first 加固流程）
 
-合并 Release PR 后，release.yml 自动执行：
+合并 Release PR（`VERSION` 变更落到 `main`）后，`release.yml` 自动触发（亦可 `workflow_dispatch` 手动指定 40 位 hex `release_sha`）。**v7.0.0 起该 workflow 是 draft-first、evaluator-gated、fail-closed 的**：所有业务判定（phase 迁移 / digest 规范化 / canonical 选择 / 状态机）集中在 `scripts/resolve-release-state.mjs` + `scripts/run-release.mjs`（均有单测），workflow YAML 只装工具链（Node 22 / Python 3.12 / uv 0.11.21）并把 token 交给编排器；第三方 Actions 全部 pin 完整 commit SHA。
 
-1. 读取 `VERSION` 文件
-2. 创建 git tag `vX.Y.Z`
-3. 从 `CHANGELOG.md` 提取发布说明
-4. 创建 GitHub Release
+流程：
+
+1. 解析 `RELEASE_SHA`（push = 该 commit；dispatch = 输入或 `main` tip），校验为 `origin/main` 祖先；从该 commit 读 `VERSION` + CHANGELOG 版本节（空则失败）。
+2. tri-state 探测：tag（`git ls-remote`，rc=2 = absent）+ release（`gh api` releases 列表，**含 draft**——published-only 的 `/releases/tags/{tag}` 探不到 draft）。
+3. **identity evaluator** → 唯一稳定 canonical identity `{sha, version, notes}` + 当前 phase。
+4. 从 canonical commit 用 uv 0.11.21 + Python 3.12 + hashed build constraints + `--require-hashes --no-config` + 固定 `SOURCE_DATE_EPOCH`（canonical commit epoch）构建 wheel + 生成精确 `.sha256` 字节。
+5. **integrity evaluator → action 状态机**：`create empty draft → re-query → upload 两资产 → re-query → 认证下载 + REST digest + 字节 + injected-core 安装校验 → 紧邻 publish 再 re-query → publish`。任一步 action 不符预期即 fail-closed。
+6. publish 后：只读 immutability 校验（仅当仓库已启用时才验，**绝不切换该 setting**）+ 最终 public-URL production installer 校验（**warn-only**）。
+
+**关键不变量**：已发布资产**绝不就地修补 / 覆盖 / 删除**——错了发新 patch 版本；失败 fail-closed 于 draft 阶段，留下未发布 draft 供人工检查/删除（`gh release delete vX.Y.Z --yes` 清理）。
 
 验证发布成功：
 
 ```bash
-# 检查 tag
-git fetch --tags
-git tag -l "v1.1.0"
-
-# 检查 GitHub Release
-gh release view v1.1.0
+git fetch --tags && git tag -l "vX.Y.Z"
+gh release view vX.Y.Z
+# 资产应恰为 wheel + .sha256 两个：
+gh release view vX.Y.Z --json assets --jq '.assets[].name'
 ```
 
 ### 3.7 Post-release develop 预 bump (v1.3 NEW)
@@ -464,6 +469,7 @@ git push origin --delete v1.1.0
 
 ## 7. 版本历史
 
+- **v1.5**（2026-07-20）：**§3.6 draft-first 加固流程**。「合并 → 自动发布」从旧 tag-first 4 步简单流程重写为 v7.0.0 起的 draft-first、evaluator-gated、fail-closed 流程（tri-state 探测 → identity/integrity evaluator → uv 从 canonical commit 构建 wheel + `.sha256` → create-draft → upload → 认证下载 + digest/字节/安装校验 → 紧邻 publish 复验 → publish → 只读 immutability + warn-only public-URL 校验）；关键不变量「已发布资产绝不就地修补，错了发新 patch」。对应 `.github/workflows/release.yml` 重写为薄壳 + 新增 `scripts/run-release.mjs`（编排器，import evaluator）/ `scripts/release-verify-install.mjs`（注入式安装校验）+ 两测试。第三方 Actions pin 完整 commit SHA。Procedural 发布顺序（§3.1–§3.5 / §3.7）不变。Non-trigger archive（minor bump，无 Framework §2.3.1 触发条件）。
 - **v1.4**（2026-07-20）：**v7.0.0 Codex dual-native sync**。§3.2 MANDATORY callout 补 `bump-version.ps1` 事务性说明（anchored value-level edit + two-phase write + 任一站点失败全量回滚，plugin scope 同步 `.claude-plugin` + `.codex-plugin` 两处 version）；§3.2.1 post-bump verification 的 CLAUDE.md grep 从只查 learn-kit 扩为 `(learn-kit|diagram-kit)`（2 plugin），quintangle 站点检查加第 4 步 `node scripts/validate-dual-host.mjs` 校 Codex `.codex-plugin/plugin.json` parity；§6 发布前检查清单加 dual-host consistency 项。Procedural release 顺序不变。Non-trigger archive（minor bump，无 Framework §2.3.1 触发条件）。
 - **v1.3.2**（2026-05-18）：§2.6 + §3.7 加 cleanup callout box —— single-PR cleanup 现可依赖 GitHub `delete_branch_on_merge=true`（v4.6.2+ 启用），bulk 场景指向 `.claude/skills/mp-git-cleanup/SKILL.md` §Bulk Cleanup Mode + `scripts/safe-bulk-cleanup.ps1`。Frontmatter related[] 加 POSTMORTEM_2026-05-18 引用。Procedural commands 完全不变。Non-trigger archive（patch revision）。
 - **v1.3.1**（2026-05-18）：scrub 外部项目引用 per `[STANDARD]_AI_Engineering_Execution_HITL_Prompt` §0.3 独立性原则；frontmatter summary + revision + §3.7 "为什么需要" callout reworded；技术流程 (§3.7 / §4.5 / §6 / `verify-develop-prebumped.yml`) 完全不变。Non-trigger archive。

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "scripts": {
-    "test": "node --test tests/validate-dual-host.test.mjs tests/run-cli.test.mjs tests/check-a6.test.mjs tests/check-prebump.test.mjs tests/resolve-release-state.test.mjs tests/generate-nlm-contract.test.mjs tests/hash-upload-corpus.test.mjs tests/bump-version.test.mjs tests/learn-kit-nlm-bridge.test.mjs tests/install-nlm-bridge.test.mjs tests/probe-learn-kit-nlm-bridge.test.mjs tests/validate-claude-plugins.test.mjs tests/optional-nlm-absent.test.mjs tests/canary-connector-drift.test.mjs tests/diagram-validator-contract.test.mjs tests/documentation-contract.test.mjs",
+    "test": "node --test tests/validate-dual-host.test.mjs tests/run-cli.test.mjs tests/check-a6.test.mjs tests/check-prebump.test.mjs tests/resolve-release-state.test.mjs tests/generate-nlm-contract.test.mjs tests/hash-upload-corpus.test.mjs tests/bump-version.test.mjs tests/learn-kit-nlm-bridge.test.mjs tests/install-nlm-bridge.test.mjs tests/probe-learn-kit-nlm-bridge.test.mjs tests/validate-claude-plugins.test.mjs tests/optional-nlm-absent.test.mjs tests/canary-connector-drift.test.mjs tests/diagram-validator-contract.test.mjs tests/documentation-contract.test.mjs tests/run-release.test.mjs tests/release-verify-install.test.mjs",
     "generate:nlm-contract": "node scripts/generate-nlm-contract.mjs all --root . --uv 0.11.21 --python 3.12 --exclude-newer 2026-07-16T00:00:00Z",
     "check:nlm-contract-generated": "node scripts/generate-nlm-contract.mjs all --root . --uv 0.11.21 --python 3.12 --exclude-newer 2026-07-16T00:00:00Z --check",
     "check:baseline-tools": "node scripts/check-tool-versions.mjs --codex 0.144.3 --claude 2.1.210 --uv 0.11.21 --bridge 4.0.0 --nlm 0.8.7",

--- a/scripts/release-verify-install.mjs
+++ b/scripts/release-verify-install.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+// Pre-publish verification that a freshly built release *installs* (plan §3 Task 3, line 524).
+//
+//   node scripts/release-verify-install.mjs --wheel <wheel-path> --checksum <checksum-path>
+//
+// Exit 0 = the assets install and the bridge's own contract passes, 1 = a verification failure,
+// 2 = bad input / the check could not be run.
+//
+// WHY AN INJECTED CORE AND NOT THE PRODUCTION CLI. The production installer only ever downloads
+// the exact pinned PUBLIC v7.0.0 URLs (install-nlm-bridge.mjs validateUrls). A *draft* release's
+// assets are not at those public URLs yet — they are only reachable through the authenticated API.
+// So the release workflow downloads the draft assets itself, and this module drives the SAME
+// installer core with an injected httpRequest that serves those downloaded bytes for the canonical
+// URLs. No install logic is duplicated: installNlmBridge does the whole job, including its own
+// post-install `--contract-json` gate and rollback-on-failure. A successful install here is the
+// proof the release wheel + checksum are installable; the post-publish public-URL check
+// (un-injected, real network) is a separate, final step in the workflow.
+//
+// The install lands entirely under a throwaway OS-temp HOME (deps.env), so nothing here touches
+// the runner's real user directories. uv itself runs under the real environment so it can discover
+// its Python 3.12 and warm cache, exactly as tests/install-nlm-bridge.test.mjs proved works; the
+// wheel install is still `--require-hashes` against the checked-in runtime lock regardless.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import {
+  installNlmBridge,
+  resolveRoots,
+  PRODUCTION_DEPS,
+  CANONICAL_WHEEL_URL,
+  CANONICAL_CHECKSUM_URL,
+  WHEEL_NAME,
+  CHECKSUM_NAME,
+  BRIDGE_VERSION,
+  CONNECTOR_VERSION,
+} from "../plugins/learn-kit/scripts/install-nlm-bridge.mjs";
+
+/** A verification rule failed — the release is not installable as built. Exit 1. */
+export class VerifyError extends Error {}
+/** Bad input / the check could not be run. Exit 2. */
+export class VerifyUsageError extends Error {}
+
+const sha256Hex = (buf) => crypto.createHash("sha256").update(buf).digest("hex");
+
+/**
+ * A one-shot httpRequest that serves exactly the two downloaded assets by their canonical URL and
+ * refuses anything else. A redirect or an unexpected URL is a harness bug, never a soft pass —
+ * these bytes were already digest-verified by the caller before they got here.
+ */
+export function localAssetHttp(wheelBuf, checksumBuf) {
+  const map = new Map([
+    [CANONICAL_WHEEL_URL, wheelBuf],
+    [CANONICAL_CHECKSUM_URL, checksumBuf],
+  ]);
+  return async (urlObj) => {
+    const href = typeof urlObj === "string" ? urlObj : urlObj?.href ?? String(urlObj);
+    const body = map.get(href);
+    if (!body) throw new VerifyError(`install-verify: unexpected request for ${href}`);
+    return { statusCode: 200, headers: {}, body };
+  };
+}
+
+/**
+ * Build installer deps whose install location is a throwaway temp HOME but whose uv/Python run for
+ * real. `resolveUv` and `envPath` are overridable so the REQUIRE_PYTHON test can stub uv resolution
+ * and pass an empty PATH (the dev box carries a foreign `nlm` that would otherwise trip the
+ * installer's launcher-collision guard); production passes the real ones.
+ */
+export function buildVerifyDeps({ wheelBuf, checksumBuf, home, resolveUv, envPath, platform } = {}) {
+  const plat = platform ?? process.platform;
+  const realHome = home ?? fs.mkdtempSync(path.join(os.tmpdir(), "lk-release-verify-"));
+  const PATH = envPath ?? process.env.PATH ?? "";
+  const env =
+    plat === "win32"
+      ? {
+          LOCALAPPDATA: path.join(realHome, "LocalAppData"),
+          SystemRoot: process.env.SystemRoot,
+          PATHEXT: process.env.PATHEXT || ".COM;.EXE;.BAT;.CMD",
+          PATH,
+        }
+      : {
+          HOME: realHome,
+          XDG_DATA_HOME: path.join(realHome, ".local", "share"),
+          XDG_BIN_HOME: path.join(realHome, ".local", "bin"),
+          PATH,
+        };
+  // The bin dir must exist for the shim write; the private root must NOT (the installer demands an
+  // empty private root and creates it itself).
+  fs.mkdirSync(plat === "win32" ? env.LOCALAPPDATA : env.XDG_BIN_HOME, { recursive: true });
+
+  return {
+    home: realHome,
+    deps: {
+      platform: plat,
+      env,
+      installerSource: PRODUCTION_DEPS.installerSource,
+      tmpdir: () => os.tmpdir(),
+      resolveUv: resolveUv ?? PRODUCTION_DEPS.resolveUv,
+      httpRequest: localAssetHttp(wheelBuf, checksumBuf),
+      // uv runs under the REAL environment (Python + warm cache discovery); the venv still lands in
+      // the temp private root via an explicit path argument, and the install is --require-hashes.
+      runUv: (uvPath, args) => spawnSync(uvPath, args, { env: process.env, encoding: "utf8", timeout: 10 * 60_000, maxBuffer: 64 * 1024 * 1024 }),
+      runPython: (py, args, { env: e }) => spawnSync(py, args, { env: e, encoding: "utf8", timeout: 5 * 60_000, maxBuffer: 64 * 1024 * 1024 }),
+    },
+  };
+}
+
+/**
+ * Install the built release assets through the injected core, prove the bridge's own
+ * `--contract-json` agrees, then uninstall and clean the temp tree. Returns a small summary.
+ *
+ * `overrides.install` and `overrides.runPython` let tests exercise the orchestration without a real
+ * toolchain; by default they are the production installer and a real spawn.
+ */
+export async function verifyReleaseInstall({ wheelPath, checksumPath }, overrides = {}) {
+  if (typeof wheelPath !== "string" || wheelPath === "") throw new VerifyUsageError("--wheel is required");
+  if (typeof checksumPath !== "string" || checksumPath === "") throw new VerifyUsageError("--checksum is required");
+
+  let wheelBuf;
+  let checksumBuf;
+  try {
+    wheelBuf = fs.readFileSync(wheelPath);
+    checksumBuf = fs.readFileSync(checksumPath);
+  } catch (e) {
+    throw new VerifyUsageError(`cannot read a release asset: ${e.message}`);
+  }
+
+  const install = overrides.install ?? installNlmBridge;
+  const built = overrides.deps
+    ? { home: overrides.home ?? null, deps: overrides.deps }
+    : buildVerifyDeps({ wheelBuf, checksumBuf, resolveUv: overrides.resolveUv, envPath: overrides.envPath });
+  const { deps, home } = built;
+
+  const wheelSha = sha256Hex(wheelBuf);
+
+  try {
+    const result = await install(
+      { action: "install", wheelUrl: CANONICAL_WHEEL_URL, checksumUrl: CANONICAL_CHECKSUM_URL },
+      deps,
+    );
+    if (!result || result.status !== "installed") {
+      throw new VerifyError(`install did not report success: ${JSON.stringify(result)}`);
+    }
+
+    const receipt = JSON.parse(fs.readFileSync(result.receiptPath, "utf8"));
+    if (receipt.wheel_sha256 !== wheelSha) throw new VerifyError(`receipt wheel_sha256 ${receipt.wheel_sha256} != built wheel ${wheelSha}`);
+    if (receipt.bridge_version !== BRIDGE_VERSION) throw new VerifyError(`receipt bridge_version ${receipt.bridge_version} != ${BRIDGE_VERSION}`);
+    if (receipt.connector_version !== CONNECTOR_VERSION) throw new VerifyError(`receipt connector_version ${receipt.connector_version} != ${CONNECTOR_VERSION}`);
+    if (!/^3\.12\.\d+$/.test(receipt.python_version || "")) throw new VerifyError(`installed Python ${receipt.python_version} is not 3.12.x`);
+    const shimKeys = Object.keys(receipt.shims || {}).sort();
+    if (shimKeys.length !== 2 || shimKeys[0] !== "learn-kit-nlm-bridge" || shimKeys[1] !== "nlm") {
+      throw new VerifyError(`receipt shims are ${JSON.stringify(shimKeys)}, expected learn-kit-nlm-bridge + nlm`);
+    }
+    for (const logical of shimKeys) {
+      const p = receipt.shims[logical].path;
+      if (!fs.existsSync(p)) throw new VerifyError(`${logical} shim missing at ${p}`);
+      if (sha256Hex(fs.readFileSync(p)) !== receipt.shims[logical].sha256) throw new VerifyError(`${logical} shim bytes drifted from the receipt`);
+    }
+
+    // Re-run the bridge's own contract for proof (the installer already gated on it; this confirms
+    // the receipt binding independently).
+    const { privateRoot } = resolveRoots(deps);
+    const py =
+      deps.platform === "win32"
+        ? path.join(privateRoot, "venv", "Scripts", "python.exe")
+        : path.join(privateRoot, "venv", "bin", "python");
+    const runPython = overrides.runPython ?? ((exe, args) => spawnSync(exe, args, { encoding: "utf8", timeout: 5 * 60_000, maxBuffer: 64 * 1024 * 1024 }));
+    const cj = runPython(py, ["-I", "-X", "utf8", "-m", "learn_kit_nlm_bridge", "--contract-json"]);
+    if (!cj || cj.status !== 0) throw new VerifyError(`post-install --contract-json failed: ${(cj && cj.stderr ? cj.stderr : "").toString().trim()}`);
+    let contract;
+    try {
+      contract = JSON.parse(cj.stdout);
+    } catch (e) {
+      throw new VerifyError(`--contract-json did not return JSON: ${e.message}`);
+    }
+    if (contract.install_receipt_sha256 !== result.receiptSha256) throw new VerifyError("contract install_receipt_sha256 != the receipt just written");
+    if (contract.instructions_policy !== "prompt-user-only") throw new VerifyError(`contract instructions_policy ${JSON.stringify(contract.instructions_policy)} != "prompt-user-only"`);
+
+    // Clean install -> uninstall proves the release also uninstalls cleanly and leaves no residue.
+    const un = await install({ action: "uninstall" }, deps);
+    if (!un || un.status !== "uninstalled") throw new VerifyError(`uninstall did not report success: ${JSON.stringify(un)}`);
+
+    return {
+      ok: true,
+      wheel_sha256: wheelSha,
+      python_version: receipt.python_version,
+      bridge_version: receipt.bridge_version,
+      connector_version: receipt.connector_version,
+      install_receipt_sha256: result.receiptSha256,
+      instructions_policy: contract.instructions_policy,
+    };
+  } finally {
+    if (home) fs.rmSync(home, { recursive: true, force: true });
+  }
+}
+
+// ------------------------------------------------------------------------------ CLI
+
+function fail(msg, code) {
+  process.stderr.write(`release-verify-install: ${msg}\n`);
+  return code;
+}
+
+async function main(argv) {
+  const a = {};
+  for (let i = 0; i < argv.length; i++) {
+    const k = argv[i];
+    if (k !== "--wheel" && k !== "--checksum") return fail(`unknown argument: ${k}`, 2);
+    const v = argv[++i];
+    if (v === undefined) return fail(`${k} requires a value`, 2);
+    a[k] = v;
+  }
+  try {
+    const r = await verifyReleaseInstall({ wheelPath: a["--wheel"], checksumPath: a["--checksum"] });
+    process.stdout.write(JSON.stringify(r) + "\n");
+    return 0;
+  } catch (e) {
+    if (e instanceof VerifyUsageError) return fail(e.message, 2);
+    if (e instanceof VerifyError) return fail(e.message, 1);
+    return fail(`unexpected: ${e.stack || e.message}`, 2);
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === fs.realpathSync(process.argv[1])) {
+  main(process.argv.slice(2)).then((code) => process.exit(code));
+}

--- a/scripts/run-release.mjs
+++ b/scripts/run-release.mjs
@@ -1,0 +1,417 @@
+#!/usr/bin/env node
+// Draft-first release orchestrator (plan §3 Task 3, lines 521–524; §2.4 evaluator contract).
+//
+//   RELEASE_SHA=<40hex> GITHUB_REPOSITORY=<owner/repo> GH_TOKEN=<token> node scripts/run-release.mjs
+//
+// Exit 0 = release created/resumed/published/verified, 1 = a policy/identity/integrity violation,
+// 2 = bad input / the run could not proceed.
+//
+// EVERY DECISION lives in resolve-release-state.mjs, which this file IMPORTS — none of the phase
+// transition, digest normalisation or canonical-selection rules are re-encoded here. This
+// orchestrator only gathers facts and performs writes; the evaluator alone says what to do next.
+// That is exactly the plan's "the workflow gathers facts and performs writes, and copies no ...
+// logic into shell" — realised as a tested Node module rather than untestable YAML shell, so the
+// draft-first state machine (which cannot be exercised end-to-end without a real GitHub release
+// API) is covered by unit tests against a simulated remote.
+//
+// ALL external I/O goes through the injected `io`, so tests drive the full progression
+// (none → draft → uploaded → published, plus every rejection) against a fake. productionIo() is the
+// only place git / gh / uv / the filesystem are touched for real.
+//
+// DRAFT-FIRST, FAIL-CLOSED. A run creates an EMPTY draft, re-queries, uploads the two assets,
+// re-queries, downloads + digest/bytes-verifies + install-verifies them, re-queries one last time
+// adjacent to publish, and only then publishes. A bug or a moving remote fails before publish,
+// leaving an unpublished draft a human can inspect and delete. A published asset is never
+// re-uploaded, overwritten or deleted — the fix for a bad publish is a new patch version.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import {
+  evaluateReleaseIdentity,
+  evaluateReleaseIntegrity,
+  checksumAssetBytes,
+  parseAssetDigest,
+  PolicyError,
+  InputError,
+} from "./resolve-release-state.mjs";
+import { WHEEL_NAME, CHECKSUM_NAME } from "../plugins/learn-kit/scripts/install-nlm-bridge.mjs";
+import { verifyReleaseInstall } from "./release-verify-install.mjs";
+
+const SHA_RE = /^[0-9a-f]{40}$/;
+const sha256Hex = (buf) => crypto.createHash("sha256").update(buf).digest("hex");
+const isSha = (v) => typeof v === "string" && SHA_RE.test(v);
+
+// ------------------------------------------------------------------ pure fact builders
+
+/** Combine the static release context with a fresh remote probe into identity facts. */
+export function mkIdentityFacts(rel, probe) {
+  return {
+    version: rel.version,
+    releaseSha: rel.releaseSha,
+    mainTipSha: rel.mainTipSha,
+    releaseShaIsMainAncestor: rel.releaseShaIsMainAncestor,
+    targetCommitVersion: rel.targetCommitVersion,
+    targetNotes: rel.targetNotes,
+    immutabilityEnabled: rel.immutabilityEnabled,
+    tag: probe.tag,
+    release: probe.release,
+  };
+}
+
+export function mkIntegrityFacts(idFacts, canonical, priorPhase, expected) {
+  return { ...idFacts, expectedCanonicalIdentity: canonical, priorPhase, expectedAssets: expected };
+}
+
+export function mkExpectedAssets(built) {
+  return {
+    wheel: { name: built.wheel.name, size: built.wheel.size, rawSha256: built.wheel.rawSha256 },
+    checksum: { name: built.checksum.name, size: built.checksum.size, rawSha256: built.checksum.rawSha256 },
+  };
+}
+
+/**
+ * Extract the raw CHANGELOG section body for a version — the text under `## [X.Y.Z]...` up to the
+ * next `## [`. This is extraction only; the evaluator normalises (CRLF/trim) and rejects an empty
+ * section, so no canonicalisation happens here.
+ */
+export function extractChangelogSection(changelog, version) {
+  const lines = String(changelog).split(/\r?\n/);
+  const head = new RegExp(`^## \\[${version.replace(/\./g, "\\.")}\\]`);
+  let i = 0;
+  for (; i < lines.length; i++) if (head.test(lines[i])) break;
+  if (i === lines.length) return "";
+  const body = [];
+  for (i++; i < lines.length; i++) {
+    if (/^## \[/.test(lines[i])) break;
+    body.push(lines[i]);
+  }
+  return body.join("\n");
+}
+
+/** Parse `gh api --paginate .../releases` (one merged array) into evaluator release facts. */
+export function parseReleaseFromList(releases, version) {
+  if (!Array.isArray(releases)) throw new InputError("releases response is not an array");
+  const tag = `v${version}`;
+  const matches = releases.filter((r) => r && r.tag_name === tag);
+  if (matches.length === 0) return { present: false };
+  if (matches.length > 1) throw new PolicyError(`more than one release carries tag ${tag} (${matches.length}); refusing to guess`);
+  const r = matches[0];
+  return {
+    present: true,
+    id: r.id,
+    tag: r.tag_name,
+    name: r.name,
+    // GitHub keeps a draft's target_commitish verbatim (the SHA we pass). A published release may
+    // report the branch name instead; treat a non-SHA as "no binding" and let the peeled tag carry
+    // identity, rather than fail a correct release on a normalised field.
+    targetCommitish: isSha(r.target_commitish) ? r.target_commitish : undefined,
+    isDraft: r.draft === true,
+    isPrerelease: r.prerelease === true,
+    body: typeof r.body === "string" ? r.body : "",
+    isImmutable: typeof r.immutable === "boolean" ? r.immutable : undefined,
+    assets: Array.isArray(r.assets)
+      ? r.assets.map((a) => ({ id: a.id, name: a.name, state: a.state, size: a.size, digest: a.digest ?? null }))
+      : [],
+  };
+}
+
+/**
+ * Verify the two draft assets against what we built: the release's REST digest must be the canonical
+ * sha256, and the on-disk downloaded bytes must hash to the same. Pure over already-fetched facts +
+ * an on-disk hash lookup, so it is unit-tested directly rather than only through the live gh path.
+ * `onDiskShaOf(name)` returns the sha256 of the downloaded asset file.
+ */
+export function verifyAssetDigests(release, expected, onDiskShaOf) {
+  if (!release || !release.present) throw new PolicyError("draft vanished before the pre-publish digest check");
+  for (const key of ["wheel", "checksum"]) {
+    const exp = expected[key];
+    const asset = (release.assets || []).find((a) => a.name === exp.name);
+    if (!asset) throw new PolicyError(`draft is missing asset ${exp.name} at the digest check`);
+    const hex = parseAssetDigest(asset.digest);
+    if (hex === null) throw new PolicyError(`asset ${exp.name} has no canonical sha256 digest (${JSON.stringify(asset.digest)})`);
+    if (hex !== exp.rawSha256) throw new PolicyError(`asset ${exp.name} REST digest ${hex} != built ${exp.rawSha256}`);
+    const onDisk = onDiskShaOf(exp.name);
+    if (onDisk !== exp.rawSha256) throw new PolicyError(`downloaded ${exp.name} bytes ${onDisk} != built ${exp.rawSha256}`);
+  }
+}
+
+// ------------------------------------------------------------------ orchestration
+
+/**
+ * The draft-first progression. `io` supplies every side effect; this function only sequences them
+ * and consults the imported evaluator. Any evaluator throw (identity/integrity/phase violation)
+ * propagates unchanged, which is the fail-closed behaviour we want.
+ */
+export async function runRelease(io) {
+  const rel = await io.resolveRelease();
+
+  // --- Stage 1: identity, from the first remote probe.
+  const idFacts = mkIdentityFacts(rel, await io.probe(rel.version));
+  const id = evaluateReleaseIdentity(idFacts);
+  const canonical = id.canonicalIdentity;
+  io.log(`canonical: v${canonical.version}@${canonical.sha.slice(0, 12)}  phase=${id.phase}`);
+
+  // --- Stage 2: build the assets from the one canonical commit.
+  const built = await io.build(canonical.sha);
+  const expected = mkExpectedAssets(built);
+  io.log(`built: wheel ${built.wheel.size}B sha=${built.wheel.rawSha256.slice(0, 12)}  checksum ${built.checksum.size}B`);
+
+  // priorPhase threads the phase observed at the previous query. The first integrity call reuses
+  // the identity probe, so its priorPhase is the identity phase and the re-derived phase matches.
+  let lastPhase = id.phase;
+  let integ = evaluateReleaseIntegrity(mkIntegrityFacts(idFacts, canonical, lastPhase, expected));
+  lastPhase = integ.phase;
+  io.log(`action=${integ.action} assetAction=${integ.assetAction}`);
+
+  if (integ.action === "noop") {
+    // The integrity evaluator only returns noop for a published release whose tag, body and both
+    // assets already verify. There is nothing left to do — and nothing to re-verify that reaching
+    // this point did not already establish.
+    io.log("release is already published and correct — nothing to do.");
+    return { result: "noop", canonical };
+  }
+
+  // Re-query the mutable remote (tag + release), rebuild facts with the last observed phase, and
+  // re-evaluate. Asserts the action is the one the progression expects, or fails closed.
+  const reeval = async (expect) => {
+    const facts = mkIntegrityFacts(mkIdentityFacts(rel, await io.probe(rel.version)), canonical, lastPhase, expected);
+    const r = evaluateReleaseIntegrity(facts);
+    lastPhase = r.phase;
+    if (expect && r.action !== expect) throw new PolicyError(`after re-query expected action=${expect}, got ${r.action}`);
+    return r;
+  };
+
+  if (integ.action === "create-draft") {
+    await io.createDraft(canonical);
+    io.log("created empty draft.");
+    integ = await reeval("resume-draft");
+  }
+
+  if (integ.action === "resume-draft") {
+    if (integ.assetAction !== "upload") throw new PolicyError(`resume-draft with assetAction=${integ.assetAction}, expected upload`);
+    await io.uploadAssets(canonical.version, built);
+    io.log("uploaded both assets to the draft.");
+    integ = await reeval("publish-draft");
+  }
+
+  if (integ.action !== "publish-draft") throw new PolicyError(`unexpected action before publish: ${integ.action}`);
+
+  // Download the draft's own assets through the authenticated API, verify their REST digest + exact
+  // bytes against what we built, then install-verify. All reads/local — no remote write.
+  await io.downloadAndVerify(canonical.version, expected);
+  io.log("draft assets downloaded, digest + bytes + install verified.");
+
+  // Adjacent-to-publish re-query. Nothing below writes to the remote until publish, so this is the
+  // last observation before the release goes public.
+  integ = await reeval("publish-draft");
+  await io.publish(canonical.version);
+  io.log(`published v${canonical.version}.`);
+
+  await io.postPublish(rel, canonical, expected);
+  return { result: "published", canonical };
+}
+
+// ------------------------------------------------------------------ production io (real git/gh/uv)
+
+function run(cmd, args, opts = {}) {
+  const r = spawnSync(cmd, args, { encoding: "utf8", maxBuffer: 64 * 1024 * 1024, ...opts });
+  return { status: r.status, stdout: r.stdout ?? "", stderr: r.stderr ?? "", error: r.error };
+}
+
+function must(cmd, args, label, opts = {}) {
+  const r = run(cmd, args, opts);
+  if (r.error) throw new InputError(`${label}: could not run ${cmd} (${r.error.message})`);
+  if (r.status !== 0) throw new PolicyError(`${label} failed (exit ${r.status}): ${(r.stderr || r.stdout).trim()}`);
+  return r.stdout;
+}
+
+const BRIDGE_DIR = "plugins/learn-kit/nlm-bridge";
+const BUILD_CONSTRAINTS = `${BRIDGE_DIR}/constraints/build-hatchling-1.27.0-py312.txt`;
+
+export function productionIo() {
+  const repo = process.env.GITHUB_REPOSITORY;
+  if (!repo || !/^[^/]+\/[^/]+$/.test(repo)) throw new InputError("GITHUB_REPOSITORY (owner/repo) is required");
+  const tmp = process.env.RUNNER_TEMP && fs.existsSync(process.env.RUNNER_TEMP) ? process.env.RUNNER_TEMP : os.tmpdir();
+
+  return {
+    log: (m) => process.stdout.write(`release: ${m}\n`),
+
+    async resolveRelease() {
+      const releaseSha = process.env.RELEASE_SHA;
+      if (!isSha(releaseSha)) throw new InputError("RELEASE_SHA must be a 40-character lowercase hex SHA");
+
+      // Fetch main once and pin its tip; later tag fetches must not move what we treat as the tip.
+      must("git", ["fetch", "--no-tags", "origin", "main"], "fetch origin main");
+      const mainTipSha = must("git", ["rev-parse", "FETCH_HEAD"], "read main tip").trim();
+      const ancestor = run("git", ["merge-base", "--is-ancestor", releaseSha, mainTipSha]);
+      if (ancestor.error) throw new InputError(`git merge-base: ${ancestor.error.message}`);
+      const releaseShaIsMainAncestor = ancestor.status === 0;
+
+      const version = must("git", ["show", `${releaseSha}:VERSION`], "read VERSION at release SHA").trim();
+      const changelog = must("git", ["show", `${releaseSha}:CHANGELOG.md`], "read CHANGELOG at release SHA");
+      const targetNotes = extractChangelogSection(changelog, version);
+
+      return {
+        releaseSha,
+        mainTipSha,
+        releaseShaIsMainAncestor,
+        version,
+        targetCommitVersion: version,
+        targetNotes,
+        immutabilityEnabled: this._probeImmutability(repo),
+      };
+    },
+
+    // Repo-level immutable-releases is read-only and best-effort: an unknown field or an API hiccup
+    // must NOT claim immutability. Default false; only a clearly-true signal enables the post-publish
+    // attestation check.
+    _probeImmutability(repository) {
+      const r = run("gh", ["api", `repos/${repository}`, "--jq", ".immutable_releases // false"]);
+      return r.status === 0 && r.stdout.trim() === "true";
+    },
+
+    async probe(version) {
+      const tagRef = `refs/tags/v${version}`;
+      const ls = run("git", ["ls-remote", "--exit-code", "origin", tagRef]);
+      // ls-remote: exit 0 = present, exit 2 = the ref is absent, anything else = a real failure.
+      let tag;
+      if (ls.status === 0) {
+        const peeled = run("git", ["ls-remote", "origin", `${tagRef}^{}`]).stdout.trim().split(/\s+/)[0];
+        const direct = ls.stdout.trim().split(/\s+/)[0];
+        tag = { present: true, sha: peeled || direct };
+      } else if (ls.status === 2) {
+        tag = { present: false };
+      } else {
+        throw new PolicyError(`git ls-remote for ${tagRef} failed (exit ${ls.status}): ${(ls.stderr || "").trim()}`);
+      }
+
+      // Releases (incl. drafts) come from the list endpoint: GET /releases/tags/{tag} never returns
+      // a draft, and a draft has no git tag yet.
+      const rel = must("gh", ["api", "--paginate", `repos/${repo}/releases`], "list releases");
+      let releases;
+      try {
+        releases = JSON.parse(rel);
+      } catch (e) {
+        throw new InputError(`releases response was not JSON: ${e.message}`);
+      }
+      return { tag, release: parseReleaseFromList(releases, version) };
+    },
+
+    async build(sha) {
+      // Build from the canonical tree. The orchestrator + evaluator are already loaded from the
+      // triggering commit, so this detach only changes what uv reads, not the code deciding things.
+      must("git", ["checkout", "--detach", "--force", sha], "checkout canonical commit");
+      const epoch = must("git", ["log", "-1", "--format=%ct", sha], "read canonical commit epoch").trim();
+      const outDir = fs.mkdtempSync(path.join(tmp, "release-wheel-"));
+      must(
+        "uv",
+        ["build", "--wheel", "--build-constraints", BUILD_CONSTRAINTS, "--require-hashes", "--no-config", "--out-dir", outDir, BRIDGE_DIR],
+        "uv build wheel",
+        { env: { ...process.env, SOURCE_DATE_EPOCH: epoch } },
+      );
+      const wheelPath = path.join(outDir, WHEEL_NAME);
+      const wheelBuf = fs.readFileSync(wheelPath);
+      const wheelSha = sha256Hex(wheelBuf);
+      const checksumBytes = checksumAssetBytes(wheelSha); // single source of the exact bytes
+      const checksumPath = path.join(outDir, CHECKSUM_NAME);
+      fs.writeFileSync(checksumPath, checksumBytes, { encoding: "utf8" });
+      return {
+        wheelPath,
+        checksumPath,
+        wheel: { name: WHEEL_NAME, size: wheelBuf.length, rawSha256: wheelSha },
+        checksum: { name: CHECKSUM_NAME, size: Buffer.byteLength(checksumBytes, "utf8"), rawSha256: sha256Hex(Buffer.from(checksumBytes, "utf8")) },
+      };
+    },
+
+    async createDraft(canonical) {
+      const notesPath = path.join(tmp, `release-notes-v${canonical.version}.md`);
+      fs.writeFileSync(notesPath, canonical.notes, { encoding: "utf8" });
+      must(
+        "gh",
+        ["release", "create", `v${canonical.version}`, "--draft", "--title", `v${canonical.version}`, "--notes-file", notesPath, "--target", canonical.sha],
+        "create draft release",
+      );
+    },
+
+    async uploadAssets(version, built) {
+      must("gh", ["release", "upload", `v${version}`, built.wheelPath, built.checksumPath], "upload release assets");
+    },
+
+    async downloadAndVerify(version, expected) {
+      const dir = fs.mkdtempSync(path.join(tmp, "release-download-"));
+      must("gh", ["release", "download", `v${version}`, "--dir", dir, "--pattern", expected.wheel.name, "--pattern", expected.checksum.name], "download draft assets");
+
+      // Re-derive the REST digest of each asset from the release facts and compare to the built
+      // digest, then the on-disk bytes, then install-verify. Belt and suspenders before publish.
+      const rel = must("gh", ["api", "--paginate", `repos/${repo}/releases`], "re-list releases for digest check");
+      const release = parseReleaseFromList(JSON.parse(rel), version);
+      verifyAssetDigests(release, expected, (name) => sha256Hex(fs.readFileSync(path.join(dir, name))));
+
+      const summary = await verifyReleaseInstall({
+        wheelPath: path.join(dir, expected.wheel.name),
+        checksumPath: path.join(dir, expected.checksum.name),
+      });
+      this.log(`install-verify ok: Python ${summary.python_version}, receipt ${summary.install_receipt_sha256.slice(0, 12)}`);
+      fs.rmSync(dir, { recursive: true, force: true });
+    },
+
+    async publish(version) {
+      must("gh", ["release", "edit", `v${version}`, "--draft=false"], "publish draft release");
+    },
+
+    async postPublish(rel, canonical, expected) {
+      const { release } = await this.probe(canonical.version);
+      if (!release.present || release.isDraft) throw new PolicyError("post-publish: the release is not published");
+
+      if (rel.immutabilityEnabled) {
+        if (release.isImmutable !== true) throw new PolicyError("immutable releases are enabled but the published release is not immutable");
+        const v = run("gh", ["release", "verify", `v${canonical.version}`, "--repo", repo]);
+        if (v.status !== 0) this.log(`WARNING: gh release verify was inconclusive (exit ${v.status}): ${(v.stderr || v.stdout).trim()}`);
+        else this.log("immutability attestation verified.");
+      } else {
+        this.log("immutable releases not enabled on this repo — not claiming immutability.");
+      }
+
+      // Final, WARN-ONLY: the production installer, un-injected, against the two public URLs. The
+      // release is already public and MUST NOT be repaired in place — a failure here is announced
+      // and fixed by a new patch, never by mutating the published assets.
+      const r = run("node", ["plugins/learn-kit/scripts/install-nlm-bridge.mjs", "install",
+        "--wheel-url", `https://github.com/${repo}/releases/download/v${canonical.version}/${expected.wheel.name}`,
+        "--checksum-url", `https://github.com/${repo}/releases/download/v${canonical.version}/${expected.checksum.name}`]);
+      if (r.status === 0) {
+        this.log("final public-URL production install succeeded.");
+        run("node", ["plugins/learn-kit/scripts/install-nlm-bridge.mjs", "uninstall"]);
+      } else {
+        this.log(`::warning::final public-URL production install did NOT succeed (exit ${r.status}). The release is published and must not be patched in place; fix via a new patch version.\n${(r.stderr || r.stdout).trim()}`);
+      }
+    },
+  };
+}
+
+// ------------------------------------------------------------------------------ CLI
+
+function fail(msg, code) {
+  process.stderr.write(`run-release: ${msg}\n`);
+  return code;
+}
+
+async function main() {
+  try {
+    const summary = await runRelease(productionIo());
+    process.stdout.write(JSON.stringify({ ok: true, ...summary }) + "\n");
+    return 0;
+  } catch (e) {
+    if (e instanceof PolicyError) return fail(e.message, 1);
+    if (e instanceof InputError) return fail(e.message, 2);
+    return fail(`unexpected: ${e.stack || e.message}`, 2);
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === fs.realpathSync(process.argv[1])) {
+  main().then((code) => process.exit(code));
+}

--- a/tests/release-verify-install.test.mjs
+++ b/tests/release-verify-install.test.mjs
@@ -1,0 +1,231 @@
+// Tests for scripts/release-verify-install.mjs.
+//
+//   1. Pure glue (localAssetHttp) and the verifyReleaseInstall orchestration against a fake
+//      installer, so the assertion/rollback logic is covered without a toolchain.
+//   2. One REQUIRE_PYTHON-gated real run: build the actual bridge wheel, then verify it installs
+//      through the injected core exactly as the release workflow will. Skips when uv is absent.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
+import { execFileSync } from "node:child_process";
+
+import {
+  localAssetHttp,
+  verifyReleaseInstall,
+  VerifyError,
+  VerifyUsageError,
+} from "../scripts/release-verify-install.mjs";
+import {
+  CANONICAL_WHEEL_URL,
+  CANONICAL_CHECKSUM_URL,
+  WHEEL_NAME,
+  CHECKSUM_NAME,
+} from "../plugins/learn-kit/scripts/install-nlm-bridge.mjs";
+
+const sha256Hex = (buf) => crypto.createHash("sha256").update(buf).digest("hex");
+
+function tmp(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+// ------------------------------------------------------------------ localAssetHttp
+
+test("localAssetHttp serves the two canonical assets by their href", async () => {
+  const wheel = Buffer.from("WHEEL");
+  const checksum = Buffer.from("CHECKSUM");
+  const http = localAssetHttp(wheel, checksum);
+  const w = await http(new URL(CANONICAL_WHEEL_URL));
+  const c = await http(new URL(CANONICAL_CHECKSUM_URL));
+  assert.equal(w.statusCode, 200);
+  assert.deepEqual(w.body, wheel);
+  assert.deepEqual(c.body, checksum);
+});
+
+test("localAssetHttp refuses any other URL (a redirect is a harness bug, not a soft pass)", async () => {
+  const http = localAssetHttp(Buffer.from("w"), Buffer.from("c"));
+  await assert.rejects(() => http(new URL("https://example.com/evil")), VerifyError);
+});
+
+// ------------------------------------------------------------------ verifyReleaseInstall (faked)
+
+// Write a wheel + checksum + a valid receipt + two shim files, and return everything
+// verifyReleaseInstall needs to be driven with a fake installer.
+function scenario(overrides = {}) {
+  const root = tmp("verify-");
+  const wheelBuf = Buffer.from("a fake but stable wheel");
+  const wheelSha = sha256Hex(wheelBuf);
+  const wheelPath = path.join(root, WHEEL_NAME);
+  const checksumPath = path.join(root, CHECKSUM_NAME);
+  fs.writeFileSync(wheelPath, wheelBuf);
+  fs.writeFileSync(checksumPath, `${wheelSha}  ${WHEEL_NAME}\n`, "utf8");
+
+  const shimA = path.join(root, "learn-kit-nlm-bridge");
+  const shimB = path.join(root, "nlm");
+  fs.writeFileSync(shimA, "shim-a");
+  fs.writeFileSync(shimB, "shim-b");
+
+  const receiptSha256 = "d".repeat(64);
+  const receipt = {
+    wheel_sha256: wheelSha,
+    bridge_version: "4.0.0",
+    connector_version: "0.8.7",
+    python_version: "3.12.13",
+    shims: {
+      "learn-kit-nlm-bridge": { path: shimA, sha256: sha256Hex(fs.readFileSync(shimA)) },
+      nlm: { path: shimB, sha256: sha256Hex(fs.readFileSync(shimB)) },
+    },
+    ...(overrides.receipt || {}),
+  };
+  if (overrides.mutateReceipt) overrides.mutateReceipt(receipt); // e.g. drift a shim sha256 or path
+  const receiptPath = path.join(root, "install-receipt.json");
+  fs.writeFileSync(receiptPath, JSON.stringify(receipt), "utf8");
+
+  const install = async (opts) => {
+    if (opts.action === "uninstall") return { status: "uninstalled" };
+    if (overrides.installStatus) return { status: overrides.installStatus };
+    return { status: "installed", receiptPath, receiptSha256 };
+  };
+  const runPython = () => ({
+    status: overrides.contractStatus ?? 0,
+    stdout: JSON.stringify(overrides.contract || { install_receipt_sha256: receiptSha256, instructions_policy: "prompt-user-only" }),
+    stderr: "",
+  });
+  const deps = { platform: "linux", env: { HOME: root, XDG_DATA_HOME: path.join(root, "share"), XDG_BIN_HOME: path.join(root, "bin"), PATH: "" } };
+
+  return { root, wheelPath, checksumPath, deps, install, runPython };
+}
+
+test("verifyReleaseInstall succeeds and returns a summary when everything agrees", async () => {
+  const s = scenario();
+  const r = await verifyReleaseInstall(
+    { wheelPath: s.wheelPath, checksumPath: s.checksumPath },
+    { deps: s.deps, install: s.install, runPython: s.runPython },
+  );
+  assert.equal(r.ok, true);
+  assert.equal(r.instructions_policy, "prompt-user-only");
+  assert.equal(r.python_version, "3.12.13");
+});
+
+test("verifyReleaseInstall fails when the installer does not report success", async () => {
+  const s = scenario({ installStatus: "failed" });
+  await assert.rejects(
+    () => verifyReleaseInstall({ wheelPath: s.wheelPath, checksumPath: s.checksumPath }, { deps: s.deps, install: s.install, runPython: s.runPython }),
+    VerifyError,
+  );
+});
+
+test("verifyReleaseInstall fails on a receipt wheel_sha256 that does not match the built wheel", async () => {
+  const s = scenario({ receipt: { wheel_sha256: "0".repeat(64) } });
+  await assert.rejects(
+    () => verifyReleaseInstall({ wheelPath: s.wheelPath, checksumPath: s.checksumPath }, { deps: s.deps, install: s.install, runPython: s.runPython }),
+    VerifyError,
+  );
+});
+
+test("verifyReleaseInstall fails when the post-install contract check exits non-zero", async () => {
+  const s = scenario({ contractStatus: 1 });
+  await assert.rejects(
+    () => verifyReleaseInstall({ wheelPath: s.wheelPath, checksumPath: s.checksumPath }, { deps: s.deps, install: s.install, runPython: s.runPython }),
+    VerifyError,
+  );
+});
+
+test("verifyReleaseInstall fails when instructions_policy is not prompt-user-only", async () => {
+  const s = scenario({ contract: { install_receipt_sha256: "d".repeat(64), instructions_policy: "auto-login" } });
+  await assert.rejects(
+    () => verifyReleaseInstall({ wheelPath: s.wheelPath, checksumPath: s.checksumPath }, { deps: s.deps, install: s.install, runPython: s.runPython }),
+    VerifyError,
+  );
+});
+
+test("verifyReleaseInstall rejects missing arguments with a usage error", async () => {
+  await assert.rejects(() => verifyReleaseInstall({ wheelPath: "", checksumPath: "x" }), VerifyUsageError);
+  await assert.rejects(() => verifyReleaseInstall({ wheelPath: "/nope/x.whl", checksumPath: "/nope/x.sha256" }), VerifyUsageError);
+});
+
+// The receipt/contract/shim integrity checks each need a negative fixture, or deleting the
+// production line that enforces them would leave the suite green (adversarial-review finding).
+async function expectVerifyError(overrides) {
+  const s = scenario(overrides);
+  await assert.rejects(
+    () => verifyReleaseInstall({ wheelPath: s.wheelPath, checksumPath: s.checksumPath }, { deps: s.deps, install: s.install, runPython: s.runPython }),
+    VerifyError,
+  );
+}
+
+test("verifyReleaseInstall rejects a receipt bridge_version that is not 4.0.0", async () => {
+  await expectVerifyError({ receipt: { bridge_version: "9.9.9" } });
+});
+
+test("verifyReleaseInstall rejects a receipt connector_version that is not 0.8.7", async () => {
+  await expectVerifyError({ receipt: { connector_version: "0.0.0" } });
+});
+
+test("verifyReleaseInstall rejects a receipt python_version that is not 3.12.x", async () => {
+  await expectVerifyError({ receipt: { python_version: "3.11.9" } });
+});
+
+test("verifyReleaseInstall rejects a shim whose recorded path does not exist", async () => {
+  await expectVerifyError({ mutateReceipt: (r) => { r.shims.nlm.path = r.shims.nlm.path + "-does-not-exist"; } });
+});
+
+test("verifyReleaseInstall rejects a shim whose on-disk bytes drift from the receipt sha256", async () => {
+  await expectVerifyError({ mutateReceipt: (r) => { r.shims.nlm.sha256 = "0".repeat(64); } });
+});
+
+test("verifyReleaseInstall rejects a contract whose install_receipt_sha256 != the receipt just written", async () => {
+  await expectVerifyError({ contract: { install_receipt_sha256: "e".repeat(64), instructions_policy: "prompt-user-only" } });
+});
+
+// ------------------------------------------------------------------ real end-to-end (gated)
+
+const BRIDGE_DIR = path.resolve("plugins/learn-kit/nlm-bridge");
+function uvInfo() {
+  try {
+    const isWin = process.platform === "win32";
+    const exts = isWin ? (process.env.PATHEXT || ".EXE").split(";") : [""];
+    for (const dir of (process.env.PATH || "").split(path.delimiter)) {
+      for (const ext of exts) {
+        const c = path.join(dir, "uv" + (isWin ? ext : ""));
+        if (fs.existsSync(c)) {
+          const v = /(\d+\.\d+\.\d+)/.exec(execFileSync(c, ["--version"], { encoding: "utf8" }))[1];
+          return { path: fs.realpathSync(c), version: v };
+        }
+      }
+    }
+  } catch { /* fall through */ }
+  return null;
+}
+
+const uv = uvInfo();
+const REQUIRE_PYTHON = process.env.REQUIRE_PYTHON === "1";
+const e2eSkip = uv ? false : REQUIRE_PYTHON ? false : "uv not available for the real verify";
+
+test("end-to-end: a freshly built wheel passes verifyReleaseInstall", { skip: e2eSkip }, async () => {
+  if (!uv || uv.version !== "0.11.21") return; // the installer pins 0.11.21
+  const out = tmp("verify-e2e-");
+  try {
+    execFileSync(uv.path, ["build", "--wheel", "--no-config", "--out-dir", out, BRIDGE_DIR], { env: process.env, stdio: ["ignore", "ignore", "pipe"] });
+    const wheelPath = path.join(out, WHEEL_NAME);
+    const wheelSha = sha256Hex(fs.readFileSync(wheelPath));
+    const checksumPath = path.join(out, CHECKSUM_NAME);
+    fs.writeFileSync(checksumPath, `${wheelSha}  ${WHEEL_NAME}\n`, "utf8");
+
+    // envPath "" + a stubbed uv resolver keep the installer's launcher-collision scan off the dev
+    // box's foreign `nlm`; uv itself still runs under the real environment for Python + cache.
+    const r = await verifyReleaseInstall(
+      { wheelPath, checksumPath },
+      { resolveUv: () => ({ path: uv.path, version: uv.version }), envPath: "" },
+    );
+    assert.equal(r.ok, true);
+    assert.equal(r.wheel_sha256, wheelSha);
+    assert.match(r.python_version, /^3\.12\.\d+$/);
+    assert.equal(r.instructions_policy, "prompt-user-only");
+  } finally {
+    fs.rmSync(out, { recursive: true, force: true });
+  }
+});

--- a/tests/run-release.test.mjs
+++ b/tests/run-release.test.mjs
@@ -1,0 +1,311 @@
+// Tests for scripts/run-release.mjs — the draft-first orchestration and its pure fact builders.
+// The orchestration is driven against a simulated remote (a fake `io`) so the whole state machine
+// runs without a real GitHub release API. Decisions still come from resolve-release-state.mjs; these
+// tests prove the orchestrator threads facts, sequences writes and fails closed correctly.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  runRelease,
+  extractChangelogSection,
+  parseReleaseFromList,
+  mkExpectedAssets,
+  verifyAssetDigests,
+} from "../scripts/run-release.mjs";
+import { PolicyError, InputError, normalizeNotes } from "../scripts/resolve-release-state.mjs";
+
+const SHA = "a".repeat(40);
+const OTHER = "b".repeat(40);
+const VERSION = "7.0.0";
+const NOTES = "### Added\n\n- codex dual-native\n";
+const WHEEL = "learn_kit_nlm_bridge-4.0.0-py3-none-any.whl";
+const CHECKSUM = `${WHEEL}.sha256`;
+const WHEEL_SHA = "1a".repeat(32);
+const CHECKSUM_SHA = "2b".repeat(32);
+
+const BUILT = {
+  wheelPath: "/tmp/w.whl",
+  checksumPath: "/tmp/w.whl.sha256",
+  wheel: { name: WHEEL, size: 1234, rawSha256: WHEEL_SHA },
+  checksum: { name: CHECKSUM, size: 99, rawSha256: CHECKSUM_SHA },
+};
+
+function uploadedAssets() {
+  return [
+    { id: 1, name: WHEEL, state: "uploaded", size: 1234, digest: `sha256:${WHEEL_SHA}` },
+    { id: 2, name: CHECKSUM, state: "uploaded", size: 99, digest: `sha256:${CHECKSUM_SHA}` },
+  ];
+}
+
+// A stateful fake remote. `state` mutates as the orchestrator writes to it, so re-queries observe
+// the effect of createDraft/uploadAssets/publish — the same progression a real remote goes through.
+function makeIo(state = {}, hooks = {}) {
+  const calls = [];
+  const rel = {
+    releaseSha: SHA,
+    mainTipSha: SHA,
+    releaseShaIsMainAncestor: true,
+    version: VERSION,
+    targetCommitVersion: VERSION,
+    targetNotes: NOTES,
+    immutabilityEnabled: false,
+  };
+  const io = {
+    calls,
+    log: () => {},
+    async resolveRelease() {
+      return { ...rel, ...(hooks.rel || {}) };
+    },
+    async probe() {
+      if (hooks.probe) return hooks.probe(state);
+      const tag = state.published ? { present: true, sha: SHA } : { present: false };
+      let release = { present: false };
+      if (state.draft || state.published) {
+        release = {
+          present: true,
+          id: 5,
+          tag: `v${VERSION}`,
+          name: `v${VERSION}`,
+          targetCommitish: SHA,
+          isDraft: !state.published,
+          isPrerelease: false,
+          body: NOTES,
+          assets: state.uploaded ? uploadedAssets() : [],
+        };
+      }
+      return { tag, release };
+    },
+    async build() {
+      calls.push("build");
+      return BUILT;
+    },
+    async createDraft() {
+      calls.push("createDraft");
+      state.draft = true;
+    },
+    async uploadAssets() {
+      calls.push("uploadAssets");
+      state.uploaded = true;
+    },
+    received: {},
+    async downloadAndVerify(version, expected) {
+      calls.push("downloadAndVerify");
+      io.received.downloadAndVerify = { version, expected };
+    },
+    async publish(version) {
+      calls.push("publish");
+      io.received.publish = { version };
+      state.published = true;
+    },
+    async postPublish() {
+      calls.push("postPublish");
+    },
+  };
+  return io;
+}
+
+test("fresh release: build → create draft → upload → verify → publish → post-publish", async () => {
+  const io = makeIo({});
+  const r = await runRelease(io);
+  assert.equal(r.result, "published");
+  assert.deepEqual(io.calls, ["build", "createDraft", "uploadAssets", "downloadAndVerify", "publish", "postPublish"]);
+  // The pre-publish verify and publish must receive the canonical version and the built assets — a
+  // stale/wrong argument here would be invisible to a call-name-only assertion.
+  assert.equal(io.received.downloadAndVerify.version, VERSION);
+  assert.deepEqual(io.received.downloadAndVerify.expected, mkExpectedAssets(BUILT));
+  assert.equal(io.received.publish.version, VERSION);
+});
+
+test("resume from an empty draft: skips create, uploads, then publishes", async () => {
+  const io = makeIo({ draft: true });
+  const r = await runRelease(io);
+  assert.equal(r.result, "published");
+  assert.deepEqual(io.calls, ["build", "uploadAssets", "downloadAndVerify", "publish", "postPublish"]);
+});
+
+test("resume from a fully-uploaded draft: verifies then publishes", async () => {
+  const io = makeIo({ draft: true, uploaded: true });
+  const r = await runRelease(io);
+  assert.equal(r.result, "published");
+  assert.deepEqual(io.calls, ["build", "downloadAndVerify", "publish", "postPublish"]);
+});
+
+test("already published and correct: noop, no writes, no re-verify", async () => {
+  const io = makeIo({ draft: true, uploaded: true, published: true });
+  const r = await runRelease(io);
+  assert.equal(r.result, "noop");
+  assert.deepEqual(io.calls, ["build"]); // build is needed to compute expected assets; nothing else runs
+});
+
+test("a foreign asset on the draft fails closed before any publish", async () => {
+  const io = makeIo({}, {
+    probe: (state) => {
+      const tag = { present: false };
+      if (!state.draft) return { tag, release: { present: false } };
+      return {
+        tag,
+        release: {
+          present: true, id: 5, tag: `v${VERSION}`, name: `v${VERSION}`, targetCommitish: SHA,
+          isDraft: true, isPrerelease: false, body: NOTES,
+          assets: [...uploadedAssets(), { id: 9, name: "surprise.txt", state: "uploaded", size: 1, digest: `sha256:${"c".repeat(64)}` }],
+        },
+      };
+    },
+  });
+  await assert.rejects(() => runRelease(io), PolicyError);
+  assert.ok(!io.calls.includes("publish"), "must not publish when a foreign asset is present");
+});
+
+test("release notes drift on the draft fails closed", async () => {
+  const io = makeIo({}, {
+    probe: (state) => {
+      const tag = { present: false };
+      if (!state.draft) return { tag, release: { present: false } };
+      return {
+        tag,
+        release: {
+          present: true, id: 5, tag: `v${VERSION}`, name: `v${VERSION}`, targetCommitish: SHA,
+          isDraft: true, isPrerelease: false, body: "### Something else entirely", assets: uploadedAssets(),
+        },
+      };
+    },
+  });
+  await assert.rejects(() => runRelease(io), PolicyError);
+  assert.ok(!io.calls.includes("publish"));
+});
+
+test("a release SHA that is not on main is rejected at identity", async () => {
+  const io = makeIo({}, { rel: { releaseShaIsMainAncestor: false } });
+  await assert.rejects(() => runRelease(io), PolicyError);
+  assert.ok(!io.calls.includes("createDraft"));
+});
+
+test("starting a brand-new release from a stale (non-tip) commit is refused", async () => {
+  const io = makeIo({}, { rel: { mainTipSha: OTHER } });
+  await assert.rejects(() => runRelease(io), PolicyError);
+});
+
+test("a draft asset whose digest disagrees with the build fails closed before publish", async () => {
+  const io = makeIo({ draft: true }, {
+    probe: () => {
+      const assets = uploadedAssets();
+      assets[0].digest = `sha256:${"e".repeat(64)}`; // wrong wheel digest
+      return {
+        tag: { present: false },
+        release: { present: true, id: 5, tag: `v${VERSION}`, name: `v${VERSION}`, targetCommitish: SHA, isDraft: true, isPrerelease: false, body: NOTES, assets },
+      };
+    },
+  });
+  await assert.rejects(() => runRelease(io), PolicyError);
+  assert.ok(!io.calls.includes("publish"), "must not publish when a draft asset digest is wrong");
+});
+
+// ------------------------------------------------------------------ verifyAssetDigests helper
+
+const EXP = {
+  wheel: { name: WHEEL, size: 1234, rawSha256: WHEEL_SHA },
+  checksum: { name: CHECKSUM, size: 99, rawSha256: CHECKSUM_SHA },
+};
+const goodOnDisk = (name) => (name === WHEEL ? WHEEL_SHA : CHECKSUM_SHA);
+
+test("verifyAssetDigests passes when both REST digest and on-disk bytes match", () => {
+  assert.doesNotThrow(() => verifyAssetDigests({ present: true, assets: uploadedAssets() }, EXP, goodOnDisk));
+});
+
+test("verifyAssetDigests rejects a vanished draft", () => {
+  assert.throws(() => verifyAssetDigests({ present: false }, EXP, goodOnDisk), PolicyError);
+});
+
+test("verifyAssetDigests rejects a missing asset", () => {
+  assert.throws(() => verifyAssetDigests({ present: true, assets: [uploadedAssets()[0]] }, EXP, goodOnDisk), PolicyError);
+});
+
+test("verifyAssetDigests rejects an absent/non-canonical digest", () => {
+  const a = uploadedAssets();
+  a[0].digest = null;
+  assert.throws(() => verifyAssetDigests({ present: true, assets: a }, EXP, goodOnDisk), PolicyError);
+});
+
+test("verifyAssetDigests rejects a REST digest that disagrees with the build", () => {
+  const a = uploadedAssets();
+  a[0].digest = `sha256:${"f".repeat(64)}`;
+  assert.throws(() => verifyAssetDigests({ present: true, assets: a }, EXP, goodOnDisk), PolicyError);
+});
+
+test("verifyAssetDigests rejects on-disk bytes that disagree with the build", () => {
+  const badOnDisk = (name) => (name === WHEEL ? "0".repeat(64) : CHECKSUM_SHA);
+  assert.throws(() => verifyAssetDigests({ present: true, assets: uploadedAssets() }, EXP, badOnDisk), PolicyError);
+});
+
+// ------------------------------------------------------------------ pure helpers
+
+test("extractChangelogSection pulls the body under the version heading only", () => {
+  const cl = [
+    "# Changelog",
+    "",
+    "## [Unreleased]",
+    "",
+    "## [7.0.0] - 2026-07-20",
+    "",
+    "### Added",
+    "- a thing",
+    "",
+    "## [6.3.1] - 2026-06-15",
+    "",
+    "- older",
+  ].join("\n");
+  const s = extractChangelogSection(cl, "7.0.0");
+  assert.match(s, /### Added/);
+  assert.match(s, /- a thing/);
+  assert.doesNotMatch(s, /older/);
+  assert.doesNotMatch(s, /Unreleased/);
+  assert.equal(normalizeNotes(s), "### Added\n- a thing");
+});
+
+test("extractChangelogSection returns empty for a missing version", () => {
+  assert.equal(extractChangelogSection("## [1.0.0]\n\n- x\n", "7.0.0"), "");
+});
+
+test("extractChangelogSection does not confuse 7.0.0 with 7.0.00-style prefixes", () => {
+  const cl = "## [7.0.0] - d\n\n- real\n\n## [7.0.0-rc] - d\n\n- rc\n";
+  assert.match(extractChangelogSection(cl, "7.0.0"), /real/);
+  assert.doesNotMatch(extractChangelogSection(cl, "7.0.0"), /rc/);
+});
+
+test("parseReleaseFromList finds a draft by tag_name and maps its fields", () => {
+  const list = [
+    { id: 1, tag_name: "v6.3.1", draft: false },
+    { id: 2, tag_name: "v7.0.0", name: "v7.0.0", target_commitish: SHA, draft: true, prerelease: false, body: NOTES, assets: [{ id: 3, name: WHEEL, state: "uploaded", size: 1234, digest: `sha256:${WHEEL_SHA}` }] },
+  ];
+  const r = parseReleaseFromList(list, "7.0.0");
+  assert.equal(r.present, true);
+  assert.equal(r.isDraft, true);
+  assert.equal(r.targetCommitish, SHA);
+  assert.equal(r.assets.length, 1);
+  assert.equal(r.assets[0].digest, `sha256:${WHEEL_SHA}`);
+});
+
+test("parseReleaseFromList reports absence when nothing matches", () => {
+  assert.deepEqual(parseReleaseFromList([{ id: 1, tag_name: "v1.0.0" }], "7.0.0"), { present: false });
+});
+
+test("parseReleaseFromList refuses to guess between duplicate tags", () => {
+  assert.throws(() => parseReleaseFromList([{ tag_name: "v7.0.0" }, { tag_name: "v7.0.0" }], "7.0.0"), PolicyError);
+});
+
+test("parseReleaseFromList treats a branch-name target_commitish as no binding", () => {
+  const r = parseReleaseFromList([{ id: 2, tag_name: "v7.0.0", target_commitish: "main", draft: false, assets: [] }], "7.0.0");
+  assert.equal(r.targetCommitish, undefined);
+});
+
+test("parseReleaseFromList rejects a non-array response", () => {
+  assert.throws(() => parseReleaseFromList({ not: "an array" }, "7.0.0"), InputError);
+});
+
+test("mkExpectedAssets carries exactly name/size/rawSha256 for both assets", () => {
+  assert.deepEqual(mkExpectedAssets(BUILT), {
+    wheel: { name: WHEEL, size: 1234, rawSha256: WHEEL_SHA },
+    checksum: { name: CHECKSUM, size: 99, rawSha256: CHECKSUM_SHA },
+  });
+});


### PR DESCRIPTION
## Summary

Hardens `release.yml` to the plan §3 Task 3 **draft-first, evaluator-gated, fail-closed** flow (deferred out of PR1). This is the release infrastructure that will drive the v7.0.0 and future releases. All business decisions stay in the already-tested `resolve-release-state.mjs`; a thin workflow drives a new **tested** Node orchestrator instead of untestable YAML shell.

## What changed

- **`.github/workflows/release.yml`** — thin: SHA-pinned third-party Actions (an elevation over the repo's `@v4` tags, per plan), pinned uv `0.11.21`, `workflow_dispatch(release_sha)` validated env-only (whole-string regex, rejects multiline), `concurrency: release-main / cancel-in-progress: false`, minimal `contents: write`. Hands the orchestrator a token.
- **`scripts/run-release.mjs`** (new) — the draft-first state machine. Imports the evaluator (no phase/digest/canonical logic in shell); performs all git/gh/uv I/O via an injectable `io`. create empty draft → re-query → upload the 2 assets → re-query → authenticated download + REST-digest + exact-bytes + injected-core install-verify → adjacent-to-publish re-query → publish. Never `--clobber`; a published asset is never re-uploaded/overwritten/deleted — a bad publish is fixed by a new patch.
- **`scripts/release-verify-install.mjs`** (new) — pre-publish install-verify: imports the production installer core and serves the *downloaded draft-asset* bytes via an injected `httpRequest` (the production CLI only accepts the public URL, so it cannot verify a draft), installs into a temp HOME, checks `--contract-json`, uninstalls.
- **Tests** (`tests/run-release.test.mjs`, `tests/release-verify-install.test.mjs`) — +26: orchestration state machine against a simulated remote (fresh / resume-from-draft / resume-from-uploaded / noop / foreign-asset / notes-drift / non-ancestor / stale-tip / digest-mismatch), the extracted `verifyAssetDigests` helper, install-verify negatives, and a `REQUIRE_PYTHON`-gated real wheel build + install.
- **`docs/runbook/[RUNBOOK]_Release_Operations.md` §3.6** — rewritten from the old tag-first flow to the hardened draft-first flow (frontmatter v1.4 → v1.5 + revision + §7 entry).
- **`package.json`** — wire the 2 new test files into `test`.

## Testing

- `REQUIRE_PWSH=1 REQUIRE_PYTHON=1 UV_OFFLINE=1 npm test` → **545 / 544 pass / 1 skip / 0 fail**.
- `validate:dual-host` 0 error / 0 warning; `claude plugin validate --strict .` pass; every workflow run-block `bash -n` clean.
- **Adversarial `/workflows` review** (17 agents, 5 lenses): 12 raw findings → **2 confirmed test-coverage gaps (fixed + mutation-verified), 10 refuted**. The two confirmed were missing negative fixtures for install-verify integrity checks and the `downloadAndVerify` digest loop; all 4 new negatives were mutation-verified to catch their target line.
- Independently confirmed the assumptions that can't be exercised without a real release: asset `digest: "sha256:<hex>"` present, `gh api --paginate .../releases` → merged array, published `target_commitish` is the branch name (handled by the `isSha()` normalization), the exact build command works offline, and the wheel is byte-reproducible with a fixed `SOURCE_DATE_EPOCH` (so the resume path works).

## Governance

- **A6: clean** — no `.github/**` or contract-script paths are in `check-a6.mjs TRIGGERS`, so no root `CLAUDE.md` sync is required (`check-a6.mjs` → `no-trigger`, exit 0).
- `validate-commits` 2/2. Bare-worktree model; branch `maintain/harden-release-yml`.
- **Honest limit**: the workflow's first real run *is* the v7.0.0 release — it is not end-to-end testable locally (needs the real GitHub release API + network). The mitigation is draft-first fail-closed: the worst realistic failure is an unpublished draft to inspect/delete, and the `publish` step only runs after the evaluator confirms two correct assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
