### PR TITLE
fix(release): harden the post-createDraft list-visibility poll

### DIFF
--- a/scripts/run-release.mjs
+++ b/scripts/run-release.mjs
@@ -46,6 +46,12 @@ const SHA_RE = /^[0-9a-f]{40}$/;
 const sha256Hex = (buf) => crypto.createHash("sha256").update(buf).digest("hex");
 const isSha = (v) => typeof v === "string" && SHA_RE.test(v);
 
+// Backoff for the post-createDraft releases-list-visibility poll. GitHub's releases list is eventually
+// consistent, so the draft this run just created can be briefly absent from `gh api .../releases`.
+// 6 probes total (1 immediate re-query + these 5 backed-off retries), ~30s of tolerance for the list
+// to catch up before failing closed. Exported so the tests bound their assertions to it, not a literal.
+export const DRAFT_VISIBILITY_BACKOFF_MS = [1000, 2000, 4000, 8000, 15000];
+
 // ------------------------------------------------------------------ pure fact builders
 
 /** Combine the static release context with a fresh remote probe into identity facts. */
@@ -186,16 +192,49 @@ export async function runRelease(io) {
     return r;
   };
 
+  // After createDraft, GitHub's releases list is eventually consistent: the draft this run just created
+  // can be briefly absent from `gh api .../releases`, during which the evaluator still reads "no release"
+  // and returns create-draft (phase=initial). Poll with backoff until it flips to resume-draft. ONLY that
+  // one transient action is tolerated — an evaluator throw (a foreign or mismatched draft) or any other
+  // action propagates immediately, and exhausting the budget fails closed too. Without this, the FIRST run
+  // of every release loses the create->re-query race and fails closed, needing a manual re-dispatch. This
+  // never risks a wrong publish: it only waits for a draft this run itself created to become observable.
+  const settleAfterCreate = async () => {
+    for (let attempt = 0; ; attempt++) {
+      const r = evaluateReleaseIntegrity(mkIntegrityFacts(mkIdentityFacts(rel, await io.probe(rel.version)), canonical, lastPhase, expected));
+      if (r.action === "resume-draft") {
+        lastPhase = r.phase;
+        return r;
+      }
+      if (r.action !== "create-draft") {
+        throw new PolicyError(`after createDraft expected resume-draft (or the transient create-draft while the releases list catches up), got ${r.action}`);
+      }
+      if (attempt >= DRAFT_VISIBILITY_BACKOFF_MS.length) {
+        const waited = Math.round(DRAFT_VISIBILITY_BACKOFF_MS.reduce((a, b) => a + b, 0) / 1000);
+        throw new PolicyError(`the draft created for v${canonical.version} never appeared in the releases list after ${attempt + 1} probes (~${waited}s of backoff); failing closed — inspect and delete the draft, then re-run`);
+      }
+      // Do NOT advance lastPhase here: the phase legitimately has not moved (the draft is not yet
+      // observable), so the eventual initial->draft transition must stay valid on the next probe.
+      io.log(`draft for v${canonical.version} not visible in the releases list yet; waiting ${DRAFT_VISIBILITY_BACKOFF_MS[attempt]}ms (probe ${attempt + 1}/${DRAFT_VISIBILITY_BACKOFF_MS.length + 1})`);
+      await io.sleep(DRAFT_VISIBILITY_BACKOFF_MS[attempt]);
+    }
+  };
+
   if (integ.action === "create-draft") {
     await io.createDraft(canonical);
     io.log("created empty draft.");
-    integ = await reeval("resume-draft");
+    integ = await settleAfterCreate();
   }
 
   if (integ.action === "resume-draft") {
     if (integ.assetAction !== "upload") throw new PolicyError(`resume-draft with assetAction=${integ.assetAction}, expected upload`);
     await io.uploadAssets(canonical.version, built);
     io.log("uploaded both assets to the draft.");
+    // This re-query is deliberately NOT polled like settleAfterCreate. `gh release upload` returns only
+    // after both assets are uploaded, and the evaluator intentionally fails closed on a partial /
+    // still-"uploading" / not-yet-digested set — states indistinguishable from a truncated or foreign
+    // upload. Retrying through those would swallow a genuine bad upload. The rare digest-population lag is
+    // an accepted, recoverable fail-closed: a re-dispatch resumes the now-correct draft, never a bad publish.
     integ = await reeval("publish-draft");
   }
 
@@ -240,6 +279,7 @@ export function productionIo() {
 
   return {
     log: (m) => process.stdout.write(`release: ${m}\n`),
+    sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
 
     async resolveRelease() {
       const releaseSha = process.env.RELEASE_SHA;

--- a/tests/run-release.test.mjs
+++ b/tests/run-release.test.mjs
@@ -12,6 +12,7 @@ import {
   parseReleaseFromList,
   mkExpectedAssets,
   verifyAssetDigests,
+  DRAFT_VISIBILITY_BACKOFF_MS,
 } from "../scripts/run-release.mjs";
 import { PolicyError, InputError, normalizeNotes } from "../scripts/resolve-release-state.mjs";
 
@@ -53,7 +54,11 @@ function makeIo(state = {}, hooks = {}) {
   };
   const io = {
     calls,
+    sleeps: [],
     log: () => {},
+    sleep: async (ms) => {
+      io.sleeps.push(ms);
+    },
     async resolveRelease() {
       return { ...rel, ...(hooks.rel || {}) };
     },
@@ -199,6 +204,95 @@ test("a draft asset whose digest disagrees with the build fails closed before pu
   });
   await assert.rejects(() => runRelease(io), PolicyError);
   assert.ok(!io.calls.includes("publish"), "must not publish when a draft asset digest is wrong");
+});
+
+// ------------------------------------------------------------------ post-create list-visibility poll
+
+// A probe that hides the freshly-created draft from the releases list for `lagPolls` reads after
+// createDraft (GitHub's eventual-consistency window), then reveals it. `Infinity` = it never appears.
+function laggyDraftProbe(lagPolls) {
+  let postCreate = 0;
+  return (state) => {
+    const lagging = state.draft && !state.published && postCreate < lagPolls;
+    if (lagging) postCreate++;
+    if ((!state.draft && !state.published) || lagging) {
+      return { tag: { present: false }, release: { present: false } };
+    }
+    return {
+      tag: state.published ? { present: true, sha: SHA } : { present: false },
+      release: {
+        present: true, id: 5, tag: `v${VERSION}`, name: `v${VERSION}`, targetCommitish: SHA,
+        isDraft: !state.published, isPrerelease: false, body: NOTES,
+        assets: state.uploaded ? uploadedAssets() : [],
+      },
+    };
+  };
+}
+
+test("post-create list lag: polls with backoff until the draft appears, then publishes", async () => {
+  const io = makeIo({}, { probe: laggyDraftProbe(3) });
+  const r = await runRelease(io);
+  assert.equal(r.result, "published");
+  assert.deepEqual(io.calls, ["build", "createDraft", "uploadAssets", "downloadAndVerify", "publish", "postPublish"]);
+  // Assert the exact recorded delays, not just the count: a sleep(0)/constant backoff would keep the
+  // count right yet complete all probes inside the replication window, reintroducing the first-run race.
+  assert.deepEqual(io.sleeps, DRAFT_VISIBILITY_BACKOFF_MS.slice(0, 3), "backs off on the exact exported schedule until the draft is visible");
+});
+
+test("post-create list lag that never resolves: fails closed after the backoff budget, no publish", async () => {
+  const io = makeIo({}, { probe: laggyDraftProbe(Infinity) });
+  await assert.rejects(
+    () => runRelease(io),
+    (e) => e instanceof PolicyError && /never appeared in the releases list/.test(e.message),
+  );
+  assert.equal(io.calls.filter((c) => c === "createDraft").length, 1, "createDraft is called once, never re-created during polling");
+  assert.ok(!io.calls.includes("publish"), "must not publish when the draft never becomes visible");
+  assert.deepEqual(io.sleeps, DRAFT_VISIBILITY_BACKOFF_MS, "exhausts exactly the exported backoff schedule (real delays, not sleep(0)) before failing closed");
+});
+
+test("no list lag: the draft is visible on the first re-query, so no backoff sleep happens", async () => {
+  const io = makeIo({});
+  const r = await runRelease(io);
+  assert.equal(r.result, "published");
+  assert.equal(io.sleeps.length, 0, "the happy path must not wait");
+});
+
+test("a mismatched draft observed right after createDraft fails closed immediately, not retried as lag", async () => {
+  // The draft appears in the list at once but with drifted notes — NOT the visibility transient. It
+  // must fail closed on the first re-query, never be retried as though the list were merely lagging.
+  const io = makeIo({}, {
+    probe: (state) => {
+      if (!state.draft) return { tag: { present: false }, release: { present: false } };
+      return {
+        tag: { present: false },
+        release: { present: true, id: 5, tag: `v${VERSION}`, name: `v${VERSION}`, targetCommitish: SHA, isDraft: true, isPrerelease: false, body: "### drifted notes", assets: [] },
+      };
+    },
+  });
+  await assert.rejects(() => runRelease(io), PolicyError);
+  assert.equal(io.sleeps.length, 0, "a genuine mismatch is not retried as a visibility lag");
+  assert.ok(!io.calls.includes("publish"));
+});
+
+test("an unexpected non-transient action right after createDraft fails closed at once (not treated as lag)", async () => {
+  // The draft appears immediately WITH correct assets — a state createDraft never produces. The
+  // evaluator returns publish-draft, which is neither resume-draft nor the create-draft transient, so
+  // the poll must reject it immediately rather than back off as though the list were catching up.
+  const io = makeIo({}, {
+    probe: (state) => {
+      if (!state.draft) return { tag: { present: false }, release: { present: false } };
+      return {
+        tag: { present: false },
+        release: { present: true, id: 5, tag: `v${VERSION}`, name: `v${VERSION}`, targetCommitish: SHA, isDraft: true, isPrerelease: false, body: NOTES, assets: uploadedAssets() },
+      };
+    },
+  });
+  await assert.rejects(
+    () => runRelease(io),
+    (e) => e instanceof PolicyError && /expected resume-draft \(or the transient create-draft/.test(e.message),
+  );
+  assert.equal(io.sleeps.length, 0, "an unexpected action is not retried as a visibility lag");
+  assert.ok(!io.calls.includes("uploadAssets") && !io.calls.includes("publish"));
 });
 
 // ------------------------------------------------------------------ verifyAssetDigests helper


### PR DESCRIPTION
## Harden the release orchestrator against the post-createDraft list-visibility race

### Problem (observed on the real v7.0.0 release)

GitHub's releases **list** endpoint (`gh api .../releases`) is eventually consistent. On the first `release.yml` run for v7.0.0, `run-release.mjs` created the empty draft, then re-queried the list **~0.7s later** — the draft had not yet replicated, so the evaluator read "no release" and returned `create-draft` again, and the old `reeval("resume-draft")` threw `expected resume-draft, got create-draft`. The run **failed closed on the first attempt** (leaving an empty draft) and only completed after a manual `workflow_dispatch` re-run. Without this fix, **every** future release's first run hits the same race.

### Fix

`settleAfterCreate()` polls after `createDraft` with a bounded backoff (`DRAFT_VISIBILITY_BACKOFF_MS = [1000,2000,4000,8000,15000]`; 6 probes, ~30s) until the evaluator flips to `resume-draft`. It tolerates **only** the specific `create-draft` transient ("list hasn't caught up"); any evaluator throw (foreign/mismatched draft) or other action propagates immediately, and exhausting the budget fails closed. `lastPhase` is intentionally not advanced during the wait so the eventual `initial→draft` transition stays legal.

**Deliberately scoped to the post-create re-query.** The post-**upload** re-query is left un-polled by design: the evaluator fails closed on partial / still-`uploading` / not-yet-digested assets — states **indistinguishable** from a truncated or foreign upload — so retrying there would swallow a genuine bad upload. That asymmetry is documented in a code comment.

**Invariant preserved:** this never risks a wrong or premature publish — it only waits for a draft this run itself created to become observable, and still fails closed on exhaustion.

### Tests (`tests/run-release.test.mjs`, +5)

- lag self-heals (polls, then publishes) — asserts the **exact** recorded backoff delays against the exported schedule (not just the count);
- lag never resolves → fails closed after exactly the backoff budget, no publish;
- no lag → zero backoff sleeps (happy path unchanged);
- a mismatched draft → fails closed immediately, not retried as lag;
- an unexpected non-transient action → fails closed at once.

All 24 existing run-release tests unchanged. **Mutation-verified** (weakened budget → caught by the budget test; disabled poll → caught by the lag test; dropped guard → caught by the unexpected-action test; `sleep(0)` → caught by the duration assertions).

### Review

Ran a 4-lens adversarial `/workflows` review (correctness / fail-closed-safety / test-vacuity / regression) with per-finding verification. The three safety/correctness lenses were clean; the test-vacuity lens surfaced that the backoff **durations** were unasserted — applied the fix (bind `io.sleeps` to the exported constant), which closes that `sleep(0)` mutation hole.

### Out of scope (deliberate)

- **No version bump / no CLAUDE.md**: `run-release.mjs` is not (currently) an A6 trigger and this is internal release infra; no user-facing surface changes. No CHANGELOG entry either (a new `[Unreleased]` block would displace `[7.0.0]` from the first changelog section and break the v7.0.0-locked `documentation-contract` test).
- **A6-trigger gap**: `run-release.mjs` + `release-verify-install.mjs` should arguably join the A6 trigger set alongside `resolve-release-state.mjs`; that + the Framework v1.7→v1.8 bump it entails is a **separate governance PR**.
