### PR TITLE
docs(marketplace): NotebookLM smoke first real run + probe citation fix

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -4,7 +4,7 @@ scope: marketplace
 summary: Marketplace documentation navigation hub — STANDARD / GUIDE / ADR / SPEC / RUNBOOK / archive / templates 索引
 owner: marketplace-maintainers
 created: 2026-05-15
-updated: 2026-07-23
+updated: 2026-07-24
 state: active
 version: v7.0.0
 domain: governance
@@ -21,6 +21,7 @@ related:
   - ./adr/[ADR]_Diagram_Kit_Addition.md
   - ./adr/[ADR]_Codex_Dual_Native_Plugin_Support.md
 revision: |
+  2026-07-24 — [RUNBOOK]_NotebookLM_Smoke_Acceptance v1.0 → v1.1：first real end-to-end run PASS（single tier + 1 mind_map 经 Gate A/B；notebook 084518eb / mind_map 5a3a0d80 / corpus 6bbc1c28；跑 develop 4.0.1 via `claude --plugin-dir` @inline，installed release 仍 4.0.0）；banner + §5 record + last-verified → 2026-07-24；顺带修 §2.2-B3 `probe:602-603` misgrounded citation。docs-only 非 A6 trigger；marketplace VERSION 不动（develop 7.0.1）
   2026-07-23 — add [RUNBOOK]_NotebookLM_Smoke_Acceptance row（plan §6 "Real NotebookLM smoke" 的 human-run write-path 验收：单 tier + 1 mind_map 经 Gate A/B 端到端；是 Manual Acceptance §2.8 decline 路径的 accept-path sibling）。docs-only 非 A6 trigger；marketplace VERSION 不动（develop 7.0.1）
   2026-07-23 — Framework v1.8: §2.7 Category 4 A6 trigger set 补 `run-release.mjs` + `release-verify-install.mjs`（release 编排器 + pre-publish install 校验器与既有 `resolve-release-state.mjs` 同级并入 A6 gate；触发面 3 → 5 release 脚本，category 结构 4 类不变）；bump [Documentation Framework] row v1.7 → v1.8；同步 `check-a6.mjs` regex + 单测 + 根 CLAUDE.md。marketplace VERSION 不动（develop 7.0.1；纯 governance/doc PR，非 release）
   2026-07-20 — v7.0.0: Codex dual-native ship。mark [ADR]_Codex_Dual_Native_Plugin_Support 状态 进行中 → accepted / shipped v7.0.0（Codex 原生包装 `.agents/plugins/marketplace.json` + 每插件 `.codex-plugin/plugin.json` + 每技能 `agents/openai.yaml` 与 `.claude-plugin/**` SSOT 并行落地）；Plugin Documentation learn-kit 3.2.0 → 4.0.0 + diagram-kit 0.1.0 → 0.2.0；learn-kit NLM 依赖措辞从 `notebooklm-mcp` + `nlm login` 改为 bridge-backed（`learn-kit-nlm-bridge`，Node 22 / uv 0.11.21+ / 用户自备 Python 3.12 + Gate A/B 同意）；Last updated → 2026-07-20 (v7.0.0)
@@ -81,7 +82,7 @@ Navigation hub for all marketplace documentation.
 | [Release Operations](./runbook/[RUNBOOK]_Release_Operations.md) | 从开发到发布的完整操作流程（Issue → PR → Release）；v1.1 起 §3.2 bump-version.ps1 MANDATORY；v1.2 起 §3.2.1 反映 CLAUDE.md script 已 cover (closes #110)；v1.3 起 §3.7 add Post-release develop pre-bump (per [`[ADR]_Develop_PreBump_Adoption`](./adr/[ADR]_Develop_PreBump_Adoption.md))；v1.3.2 起 §2.6 + §3.7 加 cleanup callout 指向 mp-git-cleanup §Bulk Mode + safe-bulk-cleanup.ps1 | 2026-05-18 |
 | [Doc Archive Procedure](./runbook/[RUNBOOK]_Doc_Archive_Procedure.md) | 4-phase 文档归档工作流 + 2 HITL gate（per Documentation Framework v1.4 §2.3，flat layout）| 2026-05-17 |
 | [Codex Dual-Native Manual Acceptance](./runbook/[RUNBOOK]_Codex_Dual_Native_Manual_Acceptance.md) | 手动验收 plan §6 "Manual surfaces"：Codex App/CLI/IDE 发现 + Claude Code + prompt/HTML injection + NLM prerequisite/consent；每 check 带 `file:line` grounding + false-pass/fail traps。v1.0 `last-verified` 为 repo-grounding 日期，非 end-to-end 跑（见 banner）| 2026-07-23 |
-| [NotebookLM Smoke Acceptance](./runbook/[RUNBOOK]_NotebookLM_Smoke_Acceptance.md) | 手动验收 plan §6 "Real NotebookLM smoke"：真实 write-path 端到端（单 tier + 1 mind_map）经 Gate A/B 驱动；每 mutation 前重验 contract+manifest；Web UI 手工核对 mind_map + 手工删 notebook。是 Manual Acceptance §2.8 decline 路径的 sibling（本 runbook 为 accept 路径）。每 check 带 `file:line` grounding + traps。v1.0 `last-verified` 为 repo-grounding 日期，非 end-to-end 跑（见 banner）| 2026-07-23 |
+| [NotebookLM Smoke Acceptance](./runbook/[RUNBOOK]_NotebookLM_Smoke_Acceptance.md) | 手动验收 plan §6 "Real NotebookLM smoke"：真实 write-path 端到端（单 tier + 1 mind_map）经 Gate A/B 驱动；每 mutation 前重验 contract+manifest；Web UI 手工核对 mind_map + 手工删 notebook。是 Manual Acceptance §2.8 decline 路径的 sibling（本 runbook 为 accept 路径）。每 check 带 `file:line` grounding + traps。**v1.1 起 `last-verified` 为真实 end-to-end 跑（2026-07-24 首跑 PASS，见 §5）** | 2026-07-24 |
 
 ## Architecture Decision Records (`docs/adr/`)
 

--- a/docs/runbook/[RUNBOOK]_NotebookLM_Smoke_Acceptance.md
+++ b/docs/runbook/[RUNBOOK]_NotebookLM_Smoke_Acceptance.md
@@ -4,10 +4,10 @@ scope: marketplace
 summary: Real end-to-end NotebookLM smoke acceptance for three-views (plan §6 "Real NotebookLM smoke")
 owner: marketplace-maintainers
 created: 2026-07-23
-updated: 2026-07-23
+updated: 2026-07-24
 state: active
-version: v1.0
-last-verified: 2026-07-23
+version: v1.1
+last-verified: 2026-07-24
 domain: release
 related:
   - ./[RUNBOOK]_Codex_Dual_Native_Manual_Acceptance.md
@@ -32,12 +32,13 @@ related:
 > this runbook establishes the accept path.
 
 > [!IMPORTANT]
-> **Scope of `last-verified: 2026-07-23`.** This records the date every step was **grounded against the
-> repo** (`develop @ 15d4749` — each command / path / tool / parameter confirmed present). It does
-> **not** claim a completed end-to-end run — no human had driven this smoke when v1.0 was authored, and
-> the NLM write path had **never** been exercised end-to-end (it was dead code until learn-kit 4.0.1
-> wired `--nlm-preflight`; see §1.1). On the first real run, set `last-verified` to that date and record
-> the outcome + the exact recorded fingerprint/URLs in §5.
+> **First real run completed 2026-07-24 (v1.1) — `last-verified: 2026-07-24` now records a genuine
+> end-to-end pass, not just repo-grounding.** The v1.0 authoring date (2026-07-23) was only *grounded
+> against the repo* (`develop @ 15d4749` — each command / path / tool / parameter confirmed present); no
+> human had driven the smoke then, and the NLM write path had **never** been exercised end-to-end (dead
+> code until learn-kit 4.0.1 wired `--nlm-preflight`; see §1.1). The 2026-07-24 run exercised it for the
+> first time — against develop's 4.0.1 via `claude --plugin-dir` (`learn-kit@inline`), since the installed
+> release was still 4.0.0 — with the full outcome + 12-key fingerprint recorded in §5.
 
 > [!WARNING]
 > **This runbook mutates a real Google/NotebookLM account.** It uploads a local Markdown file to
@@ -170,10 +171,11 @@ and reach **no** network (`--nlm-preflight` runs the bridge's local `--contract-
   node scripts/probe-learn-kit-nlm-bridge.mjs --config plugins/learn-kit/.mcp.json --server notebooklm-mcp --mode bootstrap
   ```
   > ⚠ **TRAP (never run the default smoke script).** `npm run smoke:nlm-contract` is `--mode all`
-  > (`package.json`), which includes `upstream-contract` + `auth-required` — those **drive the real
+  > (`package.json:13`), which includes `upstream-contract` + `auth-required` — those **drive the real
   > upstream** and are **forbidden** here (plan §6). Run the **raw** command with `--mode bootstrap`
-  > only. The probe script ships in the **repo**, not the installed plugin, so B3 is **N/A** if you only
-  > have the plugin installed. *`scripts/probe-learn-kit-nlm-bridge.mjs:602-603`.*
+  > only. The probe script lives at repo `scripts/probe-learn-kit-nlm-bridge.mjs`, **not** under
+  > `plugins/learn-kit/`, so it is absent from an installed plugin — B3 is **N/A** if you only have the
+  > plugin installed. *(ship-location grounded by that path; `--mode all` at `package.json:13`.)*
 
 **The 6 tools** (`mcp__plugin_learn-kit_notebooklm-mcp__<tool>`): `notebook_list`, `notebook_get`,
 `notebook_create`, `source_add`, `studio_create`, `studio_status`. `refresh_auth` / `server_info` /
@@ -333,6 +335,7 @@ node "<abs-plugin-root>/scripts/install-nlm-bridge.mjs" uninstall
 | Version | Date | last-verified | Summary |
 |---------|------|---------------|---------|
 | v1.0 | 2026-07-23 | 2026-07-23 | Initial version. Grounded against `develop @ 15d4749` (learn-kit 4.0.1, bridge wheel 4.0.0). End-to-end run **pending** — `last-verified` is the repo-grounding date, not a completed pass (see banner). First real run should append a row here with: Node version, the 12-key preflight fingerprint, the exact notebook title, the mind_map record ID, and PASS/FAIL per §3. |
+| v1.1 | 2026-07-24 | 2026-07-24 | **First real end-to-end run — PASS** (§2.1–§2.8; §2.9 W1 grounded + W2 deleted, owner-completed). Node `v22.18.0`. Preflight fingerprint (12-key, no account/profile): bridge `4.0.0` · connector `0.8.7` · Python `3.12.13`; five SHAs — receipt `ba3e8c0c…`, env `4593e190…`, public-schema `cad6561f…`, upstream-schema `bf1f384f…`, auth-guard `898311e2…`; `base_url https://notebooklm.google.com` / `stdio` / `prompt-user-only` / 6 tools. Notebook `learn-kit:[SMOKE]_learn-kit_20260724_033341` (id `084518eb-c814-4f76-ba6f-0caabbf5c18a`); 1 source `85c664f9-2882-407b-a76b-767973294aa0`; mind_map artifact `5a3a0d80-d1d6-4968-af20-6ec6bd76e24d` (status completed); manifest `a3566a80…` / corpus `6bbc1c28…`. All 5 mutations ran once, in order, with per-mutation contract+manifest re-verification; staging cleaned. Run against develop 4.0.1 via `claude --plugin-dir` (`learn-kit@inline`) — the installed release was still 4.0.0, so this validated the to-be-released code through a local override. Also fixed the §2.2-B3 `probe:602-603` misgrounded citation. |
 
 ## Appendix A — Exact strings (copy-paste)
 


### PR DESCRIPTION
## What

Backfill `[RUNBOOK]_NotebookLM_Smoke_Acceptance.md` after the **first real end-to-end run** of the NotebookLM write-path smoke (plan §6 "Real NotebookLM smoke"), plus fix the one citation defect the pre-run grounding audit found.

- **v1.0 → v1.1**: frontmatter `updated` / `last-verified` → `2026-07-24`.
- **Banner** rewritten: the smoke is now a completed end-to-end pass, not just repo-grounding.
- **§5 record row** added: Node `v22.18.0`; 12-key preflight fingerprint (bridge `4.0.0` / connector `0.8.7` / Python `3.12.13` + 5 SHAs); notebook `084518eb…`, source `85c664f9…`, mind_map artifact `5a3a0d80…`; PASS §2.1–§2.8 + §2.9 W1/W2 owner-completed.
- **§2.2-B3 citation fix**: the misgrounded `probe-learn-kit-nlm-bridge.mjs:602-603` (those lines are the `VERIFY_FLAG` map, not a ship-location statement) → re-ground ship-location by the file path + `--mode all` at `package.json:13`.
- **INDEX.md**: smoke row `last-verified` → `2026-07-24` + a revision entry.

## Why

The runbook's v1.0 `last-verified` was the repo-grounding date, **not** a completed pass — the NLM write path was dead code until learn-kit 4.0.1 wired `--nlm-preflight`. The first real run (2026-07-24) exercised it end-to-end against develop's 4.0.1 via `claude --plugin-dir` (`learn-kit@inline`; the installed release was still 4.0.0). §5 now records the real outcome per the runbook's own banner instruction.

## Scope

- **In**: the smoke runbook (`docs/runbook/`) + its INDEX row/revision.
- **Out**: no code, no CHANGELOG, no version bump. The v7.0.1 release is a separate PR.

## Risk

- Level: **Low** — docs-only.
- **A6: non-trigger** (RUNBOOK + INDEX are not in the §2.7 allowlist) → `check-a6` PASS, no CLAUDE.md sync required.
- **Not** affected by the CHANGELOG doc-contract landmine (CHANGELOG untouched).

## Verification

- `check-a6.mjs` → `A6 OK — no §2.7 allowlist trigger files in this PR`
- `validate-commits.sh origin/develop..HEAD` → 1 commit, 0 failures
- `documentation-contract.test.mjs` 11/11 · `check-a6.test.mjs` 53/53
- Pre-run grounding audit verified the runbook's ~68 `file:line` citations across 5 files with adversarial critics on the mutation-critical claims; the sole defect (`probe:602-603`) is fixed here.

## Related

- Runbook: `docs/runbook/[RUNBOOK]_NotebookLM_Smoke_Acceptance.md`
- Sibling (decline path): `[RUNBOOK]_Codex_Dual_Native_Manual_Acceptance.md` §2.8
- ADR: `[ADR]_Codex_Dual_Native_Plugin_Support.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
