### PR TITLE
test(marketplace): make CHANGELOG doc-contract version-agnostic

### DIFF
--- a/tests/documentation-contract.test.mjs
+++ b/tests/documentation-contract.test.mjs
@@ -1,12 +1,26 @@
 // tests/documentation-contract.test.mjs (plan §4 Task 5 / §6)
 //
-// Locks the v7.0.0 release-doc surface with a heading/code-fence parser so a matching phrase in a
-// HISTORICAL section can't make a naive whole-file substring check pass. Two rules of thumb:
-//   - "current release section" = the content of the FIRST `## [...]` block in a CHANGELOG (works
-//     for both `[Unreleased]` and the post-release `[7.0.0]` transform).
+// Locks the release-doc surface with a heading/code-fence parser rather than substring matching.
+// Four rules of thumb:
+//   - a disclosure set is locked to whichever SINGLE `## [...]` section carries all of it —
+//     deliberately including HISTORICAL sections, because these disclosures belong to the release
+//     that introduced them and must survive every later release landing on top. Anchoring to the
+//     newest section instead makes the lock lapse the moment anything is released after it. What
+//     stops a false pass is co-occurrence: every anchor must appear in ONE section, so phrases
+//     scattered across unrelated entries cannot add up to a pass.
+//   - structure is enforced separately: every heading must parse, and a line that merely LOOKS
+//     like a section heading is reported. See HEADING_LOOKALIKE for why an ignored heading is the
+//     dangerous case rather than a merely malformed one.
+//   - substance is checked on the newest section that ships content; an empty `## [Unreleased]`
+//     may sit above it ([RUNBOOK]_Release_Operations §3.3 prescribes exactly that after a cut).
 //   - forbidden install tokens are checked inside CODE FENCES only — the READMEs legitimately
 //     mention `uv tool install` / `--force` / bare `$three-views` in *negation* prose ("do NOT use
 //     …"), which must stay allowed.
+//
+// Deliberately NOT coupled to `VERSION`: this repo pre-bumps `develop` one patch ahead of the
+// released CHANGELOG (see [ADR]_Develop_PreBump_Adoption), so `VERSION` and the newest CHANGELOG
+// section legitimately disagree on `develop` and agree only on `main`. Asserting they match would
+// fail on `develop` in the normal steady state.
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
@@ -28,13 +42,67 @@ function fences(text) {
   return out;
 }
 
-/** Content of the first `## [...]` CHANGELOG block (the current, not-yet-historical release). */
-function firstChangelogSection(text) {
-  const idx = text.indexOf("## [");
-  assert.ok(idx !== -1, "changelog has no version section");
-  const rest = text.slice(idx + 4);
-  const next = rest.indexOf("\n## [");
-  return next === -1 ? text.slice(idx) : text.slice(idx, idx + 4 + next);
+const CHANGELOGS = ["CHANGELOG.md", "plugins/learn-kit/CHANGELOG.md", "plugins/diagram-kit/CHANGELOG.md"];
+
+const FENCE_LINE = /^ {0,3}(?:```|~~~)/;
+/** A real section heading — the exact form `run-release.mjs` greps for. */
+const SECTION_HEADING = /^## \[([^\]]+)\]/;
+/**
+ * A line TRYING to be a section heading: any ATX heading whose text opens with an optional `[`
+ * then `Unreleased` or a semver. `SECTION_HEADING` silently ignores near-misses (`##  [x]` with
+ * two spaces, `  ## [x]` indented, `### [x]`, unbracketed `## x`) — all of which render as
+ * ordinary headings, so the defect is invisible on GitHub. An ignored heading is worse than a
+ * malformed one: its release merges into the section ABOVE it, which both hides a hollow entry
+ * and lets anchors scattered across two releases look co-occurring, while `run-release.mjs` —
+ * whose lookup is likewise `^## [X.Y.Z]` — misses it and fails the release closed.
+ */
+const HEADING_LOOKALIKE = /^ {0,3}#{1,6}[ \t]*\[?\s*(?:Unreleased|v?\d+\.\d+\.\d+)/i;
+const RELEASED_HEADING = /^## \[\d+\.\d+\.\d+\] - \d{4}-\d{2}-\d{2}$/;
+const isReleaseLabel = (label) => /^\d+\.\d+\.\d+$/.test(label);
+
+/**
+ * Parse a CHANGELOG into `{ sections, malformed }`. `sections` is newest-first, each with `body`
+ * EXCLUDING its heading line so an anchor can never be satisfied by the version number in the
+ * heading itself. `malformed` collects heading lookalikes that did not parse as sections.
+ *
+ * Fence-aware: a `## [` line inside a code fence is content, not a section boundary — a release
+ * note that shows a CHANGELOG snippet must not split the entry containing it.
+ */
+function parseChangelog(text) {
+  const sections = [];
+  const malformed = [];
+  let cur = null;
+  let inFence = false;
+  text.split(/\r?\n/).forEach((line, i) => {
+    if (FENCE_LINE.test(line)) {
+      inFence = !inFence;
+    } else if (!inFence) {
+      const m = SECTION_HEADING.exec(line);
+      if (m) {
+        cur = { label: m[1], heading: line, line: i + 1, body: [] };
+        sections.push(cur);
+        return;
+      }
+      if (HEADING_LOOKALIKE.test(line)) malformed.push({ line: i + 1, text: line });
+    }
+    if (cur) cur.body.push(line);
+  });
+  return { sections: sections.map((s) => ({ ...s, body: s.body.join("\n") })), malformed };
+}
+
+/**
+ * The single section whose body carries EVERY anchor (string or RegExp), or null. Only
+ * `[Unreleased]` / `[X.Y.Z]` sections are searched, so a stray `## [notes]` block cannot be
+ * appended to host a disclosure set. Because all anchors must co-occur in ONE section, phrases
+ * scattered across unrelated entries cannot fake a pass — while the lock still survives any
+ * number of newer sections landing above it.
+ */
+function sectionCarryingAll(text, anchors) {
+  return (
+    parseChangelog(text)
+      .sections.filter((s) => s.label === "Unreleased" || isReleaseLabel(s.label))
+      .find((s) => anchors.every((a) => (a instanceof RegExp ? a.test(s.body) : s.body.includes(a)))) ?? null
+  );
 }
 
 /** True if any fenced block contains `needle`. */
@@ -42,10 +110,118 @@ const inAnyFence = (text, needle) => fences(text).some((f) => f.code.includes(ne
 
 // ------------------------------------------------------------------ CHANGELOGs
 
-test("root CHANGELOG current section carries the NLM-only BREAKING anchors", () => {
-  const section = firstChangelogSection(read("CHANGELOG.md"));
-  assert.ok(section.trim().length > 200, "current changelog section must not be a hollow heading");
-  for (const anchor of [
+// Parser self-tests. Every CHANGELOG check below is only as strong as this parser, and its failure
+// mode is SILENCE — an unrecognised heading merges into the section above rather than erroring — so
+// it is exercised directly against synthetic input, not only against the real files.
+test("parseChangelog: section boundaries, heading-free bodies, fence blindness fixed", () => {
+  const { sections, malformed } = parseChangelog(
+    [
+      "# Changelog",
+      "",
+      "## [Unreleased]",
+      "",
+      "## [1.2.0] - 2026-01-02",
+      "",
+      "- real 1.2.0 content",
+      "",
+      "```markdown",
+      "## [9.9.9] - 2020-01-01",
+      "```",
+      "",
+      "- still 1.2.0",
+      "",
+      "## [1.1.0] - 2026-01-01",
+      "",
+      "- older",
+    ].join("\n"),
+  );
+  assert.deepEqual(malformed, [], "well-formed input must report no lookalikes");
+  assert.deepEqual(
+    sections.map((s) => s.label),
+    ["Unreleased", "1.2.0", "1.1.0"],
+    "a fenced heading must not open a section",
+  );
+  assert.equal(sections[0].body.trim(), "", "an empty [Unreleased] must have an empty body");
+  assert.ok(sections[1].body.includes("still 1.2.0"), "a fenced heading must not close the section either");
+  assert.ok(!sections[1].body.includes("## [1.2.0]"), "a body must exclude its own heading line");
+  assert.ok(sections[1].body.includes("## [9.9.9]"), "fenced text stays in the body as content");
+});
+
+test("parseChangelog: flags heading lookalikes, leaves ordinary prose alone", () => {
+  for (const bad of [
+    "##  [1.2.0] - 2026-01-02", // two spaces
+    "  ## [1.2.0] - 2026-01-02", // indented
+    "### [1.2.0] - 2026-01-02", // wrong level
+    "## 1.2.0 - 2026-01-02", // unbracketed
+    "### Unreleased",
+  ]) {
+    const { sections, malformed } = parseChangelog(`## [1.0.0] - 2026-01-01\n\n- x\n\n${bad}\n\n- y\n`);
+    assert.equal(malformed.length, 1, `must flag lookalike: ${JSON.stringify(bad)}`);
+    assert.equal(malformed[0].text, bad);
+    assert.equal(sections.length, 1, `lookalike must not open a section: ${JSON.stringify(bad)}`);
+  }
+  for (const fine of ["### Added", "### Fixed", "# Changelog", "- 1.2.0 shipped on Tuesday", "## Notes"]) {
+    const { malformed } = parseChangelog(`## [1.0.0] - 2026-01-01\n\n${fine}\n\n- y\n`);
+    assert.deepEqual(malformed, [], `must not flag ordinary line: ${JSON.stringify(fine)}`);
+  }
+});
+
+// A heading that only LOOKS like a section heading is the failure this parser exists to surface:
+// it renders identically on GitHub, so nothing but a byte-level check catches it.
+test("no CHANGELOG has a heading that only looks like a section heading", () => {
+  for (const rel of CHANGELOGS) {
+    const { malformed } = parseChangelog(read(rel));
+    assert.deepEqual(
+      malformed,
+      [],
+      `${rel}: heading(s) that neither parse as "## [label]" nor read as prose — ` +
+        `run-release.mjs would miss them too: ${JSON.stringify(malformed)}`,
+    );
+  }
+});
+
+test("every CHANGELOG section heading has the exact shape run-release.mjs greps for", () => {
+  for (const rel of CHANGELOGS) {
+    for (const s of parseChangelog(read(rel)).sections) {
+      if (s.label === "Unreleased") {
+        assert.equal(s.heading.trim(), "## [Unreleased]", `${rel}:${s.line}: malformed Unreleased heading`);
+      } else {
+        assert.ok(isReleaseLabel(s.label), `${rel}:${s.line}: label must be [Unreleased] or [X.Y.Z], got "${s.label}"`);
+        assert.match(
+          s.heading,
+          RELEASED_HEADING,
+          `${rel}:${s.line}: released heading must be "## [X.Y.Z] - YYYY-MM-DD", got "${s.heading}"`,
+        );
+      }
+    }
+  }
+});
+
+// Substance is checked on the newest section that actually SHIPS content. An empty `## [Unreleased]`
+// may legitimately sit on top — [RUNBOOK]_Release_Operations §3.3 prescribes exactly that shape
+// after a release cut — so anchoring this to the literally-newest section would reject the repo's
+// own documented transform.
+test("the newest shipping CHANGELOG section is substantive and names its own version", () => {
+  for (const [rel, minBody] of [
+    ["CHANGELOG.md", 200],
+    ["plugins/learn-kit/CHANGELOG.md", 100],
+    ["plugins/diagram-kit/CHANGELOG.md", 100],
+  ]) {
+    const { sections } = parseChangelog(read(rel));
+    assert.ok(sections.length, `${rel}: changelog has no version section`);
+    const s = sections.find((x) => !(x.label === "Unreleased" && x.body.trim() === ""));
+    assert.ok(s, `${rel}: every section is an empty [Unreleased] staging block`);
+    assert.ok(s.body.trim().length > minBody, `${rel}: [${s.label}] must not be a hollow heading`);
+    if (isReleaseLabel(s.label)) {
+      assert.ok(s.body.includes(s.label), `${rel}: [${s.label}] body must name its own version`);
+    }
+  }
+});
+
+// Permanent disclosure locks. These stay pinned to whichever section carries them (today the
+// v7.0.0 / learn-kit 4.0.0 entries) no matter how many releases land on top.
+test("root CHANGELOG permanently carries the NLM-only BREAKING disclosures in one section", () => {
+  const section = sectionCarryingAll(read("CHANGELOG.md"), [
     "NLM-only BREAKING",
     "7.0.0",
     "4.0.0",
@@ -58,23 +234,28 @@ test("root CHANGELOG current section carries the NLM-only BREAKING anchors", () 
     "Gate A/B",
     "learn-kit-nlm-bridge",
     "nlm login",
-  ]) {
-    assert.ok(section.includes(anchor), `root CHANGELOG current section must mention "${anchor}"`);
-  }
+  ]);
+  assert.ok(section, "no single root CHANGELOG section carries the full NLM-only BREAKING disclosure set");
 });
 
-test("learn-kit CHANGELOG current section marks the 4.0.0 NLM break", () => {
-  const section = firstChangelogSection(read("plugins/learn-kit/CHANGELOG.md"));
-  assert.ok(section.trim().length > 100, "hollow section");
-  for (const anchor of ["4.0.0", "BREAKING", "learn-kit-nlm-bridge", "Node.js 22+", "6-tool", "Gate A/B"]) {
-    assert.ok(section.includes(anchor), `learn-kit CHANGELOG must mention "${anchor}"`);
-  }
+test("learn-kit CHANGELOG permanently marks the 4.0.0 NLM break in one section", () => {
+  const section = sectionCarryingAll(read("plugins/learn-kit/CHANGELOG.md"), [
+    "4.0.0",
+    "BREAKING",
+    "learn-kit-nlm-bridge",
+    "Node.js 22+",
+    "6-tool",
+    "Gate A/B",
+  ]);
+  assert.ok(section, "no single learn-kit CHANGELOG section marks the 4.0.0 NLM break");
 });
 
-test("diagram-kit CHANGELOG current section marks the 0.2.0 bump", () => {
-  const section = firstChangelogSection(read("plugins/diagram-kit/CHANGELOG.md"));
-  assert.ok(section.includes("0.2.0"), "diagram-kit CHANGELOG must mention 0.2.0");
-  assert.match(section, /Codex|dual-host|host-neutral/, "must note the Codex / host-neutral change");
+test("diagram-kit CHANGELOG permanently marks the 0.2.0 Codex bump in one section", () => {
+  const section = sectionCarryingAll(read("plugins/diagram-kit/CHANGELOG.md"), [
+    "0.2.0",
+    /Codex|dual-host|host-neutral/,
+  ]);
+  assert.ok(section, "no single diagram-kit CHANGELOG section marks the 0.2.0 Codex / host-neutral change");
 });
 
 // ------------------------------------------------------------------ root README


### PR DESCRIPTION
## Bug 描述

`tests/documentation-contract.test.mjs` 把 root CHANGELOG 的 12 个 anchor 锁在**第一个** `## [` 节上。发布 v7.0.1 必须新增顶节（`run-release.mjs:296` 按 `^## \[7\.0\.1\]` 取 release notes），于是该 test 必挂 —— 而修它是 `test` 类 commit，§5 branch-type 矩阵**禁止** `release/*` 携带。这是发布前必须先拆掉的地雷。

第二个、更严重的问题：那个锁**只在 7.0.0 还是最新节时有效**。任何新节落到上面，NLM-only BREAKING 披露就**完全不再被检查**。

## 根因分析

`firstChangelogSection()` 把"当前发布节"定义为文件里第一个 `## [` 块，于是"必须声明这些披露"这一意图被绑死在**位置**而非**内容**上。位置每次发布都变，意图不变。

## 修复方案

拆成两个正交意图：

- **披露锁** — 钉在**携带全部 anchor 的那一个节**上（有意包含历史节：披露属于引入它的那个版本，必须在其后所有发布中存活）。防伪造靠 co-occurrence：所有 anchor 必须落在**同一节**，散落在不同条目里凑不出 pass。
- **结构校验** — 独立进行：每个 heading 必须解析；只是"长得像" heading 的行会被**报出来**。

配套加固（均来自对抗审查，见下）：

- 解析器**感知 code fence** —— 发布说明里引用 CHANGELOG 片段不再被误判为分节。
- 解析器**报告 heading lookalike**。这是最危险的一类：`##  [x]`（两个空格）、`  ## [x]`、`### [x]`、无括号 `## x` 在 GitHub 上**渲染完全相同**，旧解析器直接静默丢弃 —— 该版本被并进上一节，既掩盖空洞条目，又让**跨两个版本散落的 anchor 看起来同节**；与此同时 `run-release.mjs`（同款 `^## [X.Y.Z]` 查找）也找不到它，发布 fail closed。现在这份静默变成具名失败。
- 节 body **不含自身 heading 行** —— anchor 不能靠 heading 里的版本号蒙混。
- 充实度检查落在**最新的有内容节**，不是字面最新节 —— [RUNBOOK]_Release_Operations §3.3 明确规定发布后在新版本节**上方保留空的 `## [Unreleased]`**；钉在字面最新节会否决本仓自己的文档化流程。该节还必须**提到自己的版本号**，补回旧 anchor 列表提供的内容约束。
- 披露只在 `[Unreleased]` / `[X.Y.Z]` 节中搜索 —— 不能新挂一个 `## [7.0.0-notes]` 来寄存。

**有意不与 `VERSION` 耦合**：develop 恒比已发布 CHANGELOG 预 bump 一个 patch，两者在 develop 上本就应该不一致。

## 影响范围

无。仅 `tests/documentation-contract.test.mjs` 一个文件；未触碰任何 plugin / skill / CHANGELOG / 生成物。**非 A6 trigger**（`tests/**` 不在 §2.7 allowlist，已本机跑 `check-a6.mjs` 确认 `A6 OK`）。

## 自检结果

- [x] Bug 已复现并验证修复 —— 复现：模拟真实 v7.0.1 transform 后旧 test 必挂
- [x] 无引入新的回归问题 —— full suite **570 / 569 pass / 1 skip / 0 fail**；`validate:dual-host` 0 error 0 warning；`check:nlm-contract-generated` OK；`claude plugin validate --strict .` passed
- [x] 无残留调试代码
- [x] Commit message 符合规范（单个 `test` commit，`bugfix/*` 允许 `fix`/`test`/`docs`）
- [ ] CHANGELOG.md `[Unreleased]` 区块已更新 —— **N/A 并明示**：root CHANGELOG 当前没有 `[Unreleased]` 节，#172–#180 这一窗口内**没有任何 PR** 写过 CHANGELOG 条目（发布时统一撰写）。本次变更会并入即将到来的 `## [7.0.1]` release notes。

## 验证

**Mutation-verified 18/18**（harness 在仓外，逐案覆盖每一条审查发现）：

- **PASS**（不得误杀）：真实 v7.0.1 transform · 其上再叠一个 7.0.2 · RUNBOOK §3.3 的空 `[Unreleased]` 形态 · 节内 fenced CHANGELOG 示例
- **FAIL**（必须抓到）：整节删除 · 真散落 · 被 lookalike heading 掩盖的散落 · 空洞节 · 4 种 lookalike heading · 2 种畸形 heading · 节不提自己版本号 · 披露被挪到非发布节 · learn-kit 披露删除 · anchor 仅由 heading 满足

解析器**自身**的单测已随本 PR 提交（`parseChangelog:` 两个 test）—— 它的失败模式是**静默**而非报错，不该只靠仓外 harness 保证。

> [!NOTE]
> 本 PR 的第一版经满强度对抗审查（22 候选 → **6 confirmed** / 16 refuted）后重写。6 条全部是我自己引入或未覆盖的真缺陷，其中 1 条 blocker：充实度检查会**否决 RUNBOOK §3.3 规定的发布形态**，即在发布当天才会撞上。上面的加固与 mutation 用例逐条对应。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
